### PR TITLE
docs(log): 日志清理 — Todo→文档注释, 确认结构化日志一致性

### DIFF
--- a/go-common/log/config.go
+++ b/go-common/log/config.go
@@ -17,8 +17,13 @@ type Config struct {
 	// File 文件日志配置。
 	File FileConfig `yaml:"file" json:"file"`
 
-	// Categories 分类日志配置。
-	// TODO: NewLogger 尚未读取此字段；当前仅支持通过 Logger.WithCategory 动态创建子 Logger。
+	// Categories 分类日志配置（按分类输出到不同文件）。
+	//
+	// 当前状态：NewLogger 仅在初始化时检测此字段并输出 warning，不自动创建子 Logger。
+	// 运行时通过 Logger.WithCategory 动态创建分类子 Logger。
+	//
+	// 后续计划：支持在 NewLogger 阶段根据 Categories 配置自动预创建子 Logger，
+	// 以支持按分类写入独立日志文件、覆盖全局 Level。
 	Categories map[string]CategoryConfig `yaml:"categories" json:"categories"`
 
 	// Masking 敏感数据脱敏配置。


### PR DESCRIPTION
## What

维度 4: 日志/可观测性清理。

## Changes

- `go-common/log/config.go`: 将 Categories 字段的 TODO 替换为结构化文档注释，说明当前行为（运行时 WithCategory）和后续计划（初始化时预创建子 Logger）
- 全局扫描确认：无 `fmt.Print` / `log.Print` / `log.Fatal` 残留
- 全局扫描确认：无 printf 风格结构化日志调用

## Validation
- [x] `go build ./...` 通过
- [x] `go test ./... -count=1` 通过
- [x] pre-commit hooks 通过
