### PR TITLE
feat: upgrade golangci-lint config to v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,34 +1,44 @@
+version: "2"
 run:
-  timeout: 5m
   modules-download-mode: readonly
-
 linters:
   enable:
-    - gofmt
-    - goimports
+    - gocritic
     - misspell
     - revive
     - unconvert
     - unparam
-    - gocritic
-
-linters-settings:
-  misspell:
-    locale: US
-  revive:
-    rules:
-      - name: exported
-        arguments:
-          - disableStutteringCheck
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - style
-    disabled-checks:
-      - ifElseChain
-      - unnamedResult
-
+  settings:
+    gocritic:
+      disabled-checks:
+        - ifElseChain
+        - unnamedResult
+      enabled-tags:
+        - diagnostic
+        - style
+    misspell:
+      locale: US
+    revive:
+      rules:
+        - name: exported
+          arguments:
+            - disableStutteringCheck
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  exclude-use-default: false
   max-issues-per-linter: 50
   max-same-issues: 10
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/go-common/auth/ak_test.go
+++ b/go-common/auth/ak_test.go
@@ -62,7 +62,7 @@ func TestRefreshSK_SameInputProducesConsistentFormat(t *testing.T) {
 
 	// All chars should be hex
 	for _, ch := range sk {
-		if !((ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f')) {
+		if (ch < '0' || ch > '9') && (ch < 'a' || ch > 'f') {
 			t.Errorf("RefreshSK contains non-hex char: %c", ch)
 		}
 	}

--- a/go-common/captcha/cache.go
+++ b/go-common/captcha/cache.go
@@ -160,22 +160,22 @@ func (c *CacheStore) Set(id, value string) error {
 }
 
 // Get 实现 base64Captcha.Store 接口。
-func (c *CacheStore) Get(id string, clear bool) string {
+func (c *CacheStore) Get(id string, shouldClear bool) string {
 	preKey, _ := c.snapshot()
 	key := preKey + id
 	val, ok, _ := c.cache.Get(key)
 	if !ok {
 		return ""
 	}
-	if clear {
+	if shouldClear {
 		c.cache.Delete(key)
 	}
 	return val
 }
 
 // Verify 实现 base64Captcha.Store 接口。
-func (c *CacheStore) Verify(id, answer string, clear bool) bool {
-	v := c.Get(id, clear)
+func (c *CacheStore) Verify(id, answer string, shouldClear bool) bool {
+	v := c.Get(id, shouldClear)
 	return v == answer
 }
 

--- a/go-common/captcha/image.go
+++ b/go-common/captcha/image.go
@@ -126,7 +126,7 @@ func (ic *ImageCaptcha) Generate() (id, b64s, answer string, err error) {
 }
 
 // Verify 校验用户输入是否与验证码匹配。
-// clear=true 时校验通过后自动清除缓存（一次性使用）。
-func (ic *ImageCaptcha) Verify(id, answer string, clear bool) bool {
-	return ic.captcha.Verify(id, answer, clear)
+// shouldClear=true 时校验通过后自动清除缓存（一次性使用）。
+func (ic *ImageCaptcha) Verify(id, answer string, shouldClear bool) bool {
+	return ic.captcha.Verify(id, answer, shouldClear)
 }

--- a/go-common/log/new_logger.go
+++ b/go-common/log/new_logger.go
@@ -67,7 +67,7 @@ func createOutputHandler(w io.Writer, cfg Config) slog.Handler {
 
 // WithCategory 创建带分类的子 Logger。
 func (l *Logger) WithCategory(category string) *Logger {
-	handler := NewCategoryHandler(l.Logger.Handler(), category)
+	handler := NewCategoryHandler(l.Handler(), category)
 	return &Logger{
 		Logger: slog.New(handler),
 		level:  l.level,

--- a/go-framework/hertz/log/adapter.go
+++ b/go-framework/hertz/log/adapter.go
@@ -132,5 +132,5 @@ func (a *HertzAdapter) SetLevel(level hlog.Level) { a.level = level }
 func (a *HertzAdapter) SetOutput(w io.Writer) { a.writer = w }
 
 func (a *HertzAdapter) log(level slog.Level, msg string) {
-	a.logger.Logger.LogAttrs(context.Background(), level, msg)
+	a.logger.LogAttrs(context.Background(), level, msg)
 }

--- a/go-framework/kitex/log/adapter.go
+++ b/go-framework/kitex/log/adapter.go
@@ -132,5 +132,5 @@ func (a *KitexAdapter) SetLevel(level klog.Level) { a.level = level }
 func (a *KitexAdapter) SetOutput(w io.Writer) { a.writer = w }
 
 func (a *KitexAdapter) log(level slog.Level, msg string) {
-	a.logger.Logger.LogAttrs(context.Background(), level, msg)
+	a.logger.LogAttrs(context.Background(), level, msg)
 }

--- a/go-framework/kitex/middleware/accesslog_test.go
+++ b/go-framework/kitex/middleware/accesslog_test.go
@@ -35,7 +35,7 @@ func TestAccessLog_Kitex_Error(t *testing.T) {
 
 func TestAccessLog_Kitex_TypeCompatibility(t *testing.T) {
 	// Verify Middleware type is compatible with kitex endpoint.Middleware
-	var mw Middleware = AccessLog()
+	mw := AccessLog()
 	assert.NotNil(t, mw)
 
 	// Verify Endpoint type

--- a/go-framework/kitex/observability/tracer.go
+++ b/go-framework/kitex/observability/tracer.go
@@ -84,7 +84,7 @@ func (s *serverTracer) Finish(ctx context.Context) {
 	injectStatsEventsToSpan(span, st)
 
 	// 错误处理
-	if err, panicMsg := parseRPCError(ri); err != nil || panicMsg != "" {
+	if panicMsg, err := parseRPCError(ri); err != nil || panicMsg != "" {
 		recordErrorSpanWithStack(span, err, panicMsg)
 	}
 
@@ -154,7 +154,7 @@ func (c *clientTracer) Finish(ctx context.Context) {
 
 	injectStatsEventsToSpan(span, st)
 
-	if err, panicMsg := parseRPCError(ri); err != nil || panicMsg != "" {
+	if panicMsg, err := parseRPCError(ri); err != nil || panicMsg != "" {
 		recordErrorSpanWithStack(span, err, panicMsg)
 	}
 
@@ -190,10 +190,10 @@ func injectStatsEventsToSpan(span oteltrace.Span, st rpcinfo.RPCStats) {
 }
 
 // parseRPCError 从 RPCInfo 中提取错误信息。
-func parseRPCError(ri rpcinfo.RPCInfo) (rpcErr error, panicMsg string) {
+func parseRPCError(ri rpcinfo.RPCInfo) (panicMsg string, rpcErr error) {
 	st := ri.Stats()
 	if st == nil {
-		return nil, ""
+		return "", nil
 	}
 
 	rpcErr = st.Error()


### PR DESCRIPTION
## 变更内容

### 配置迁移
- 使用 `golangci-lint migrate` 将 `.golangci.yml` 迁移到 v2 格式
- 新增 `version: "2"` 字段（v2 必需）
- `linters-settings` → `linters.settings`（嵌套结构）
- `gofmt`/`goimports` 移到新的 `formatters` 部分
- 移除废弃的 `run.timeout`（v2 默认无超时）
- `issues.exclude-use-default: false` → `linters.exclusions.generated: lax`

### 修复新发现的 lint 问题

| 问题 | 位置 | 修复方式 |
|------|------|----------|
| `builtinShadow` | captcha/cache.go, captcha/image.go | 参数名 `clear` → `shouldClear` |
| `QF1001` | auth/ak_test.go | 应用 De Morgan 定律 |
| `QF1008` | log/new_logger.go, hertz/log/adapter.go, kitex/log/adapter.go | 移除冗余的嵌入字段选择器 |
| `ST1023` | kitex/middleware/accesslog_test.go | 使用类型推断 |
| `ST1008` | kitex/observability/tracer.go | 调整返回顺序（error 放最后） |

### 验证
- ✅ `golangci-lint config verify` 通过
- ✅ `golangci-lint run ./...` 无报错
- ✅ `go test ./... -count=1` 全部通过

Closes #17