### PR TITLE
chore(ci): align golangci-lint to v2 and re-enable CI lint step

### DIFF
--- a/.claude/rules/go.md
+++ b/.claude/rules/go.md
@@ -149,6 +149,12 @@ defer f.Close()          // errcheck 报错
 
 ### 8.6 Workspace 下运行 lint
 
+**所需版本：golangci-lint v2（>= v2.12.2）**。`.golangci.yml` 为 v2 格式，用 v1 运行会报 *"configuration file for golangci-lint v2 with golangci-lint v1"* 而失败。升级：
+
+```bash
+go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+```
+
 golangci-lint 不支持 workspace 根目录 `./...`，必须逐 module 运行：
 
 ```bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,14 +39,11 @@ jobs:
       - name: go test
         run: go test ./${{ matrix.module }}/... -count=1 -race -coverprofile=${{ matrix.module }}-coverage.out
 
-      # golangci-lint 暂不可用 — 等待 Go 1.25 兼容版本
-      # https://github.com/golangci/golangci-lint/issues
-      # - name: golangci-lint
-      #   uses: golangci/golangci-lint-action@v7
-      #   with:
-      #     version: v2.2.0
-      #     working-directory: ${{ matrix.module }}
-      #     args: --timeout=5m
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12.2
+          args: --timeout=5m ./${{ matrix.module }}/...
 
       - name: upload coverage
         if: success() || failure()

--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ defer closeFn()
 
 Go 1.25+
 
+golangci-lint v2 (>= v2.12.2) — 用于本地静态分析（CI 已启用）。安装/升级：
+
+```bash
+go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+```
+
 ## Migration
 
 See [specs/05_migration_guide.md](./specs/05_migration_guide.md) for migrating from legacy go-tools.

--- a/go-auth/jwt/token.go
+++ b/go-auth/jwt/token.go
@@ -125,7 +125,7 @@ func extractRegisteredClaims(claims gojwt.Claims) *gojwt.RegisteredClaims {
 // extractEmbeddedRegisteredClaims 通过反射查找嵌入的 RegisteredClaims 字段。
 func extractEmbeddedRegisteredClaims(claims gojwt.Claims) *gojwt.RegisteredClaims {
 	v := reflect.ValueOf(claims)
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		if v.IsNil() {
 			return nil
 		}


### PR DESCRIPTION
## Summary

对齐 golangci-lint 到 v2，重新启用 CI lint 步骤，修复启用后暴露的唯一违规。

## Changes

1. **CI** (`.github/workflows/ci.yml`): 取消注释并更新 golangci-lint 步骤
   - `golangci/golangci-lint-action@v9`, `version: v2.12.2`
   - 从仓库根目录按 matrix module 运行（确保发现根目录 `.golangci.yml`）
   - 删除「暂不可用」过时注释
2. **Code** (`go-auth/jwt/token.go:128`): `reflect.Ptr` → `reflect.Pointer`
   - 废弃别名替换，值不变，行为完全一致
   - 修复 govet(inline) 违规，使 v2 lint 全绿
3. **Docs**: README.md Requirements + `.claude/rules/go.md` §8.6
   - 注明所需 golangci-lint v2 (>= v2.12.2) 及升级命令

## Verification (v2.12.2)

| Check | go-common | go-auth | go-middleware | go-framework |
|-------|-----------|---------|---------------|--------------|
| golangci-lint | ✅ 0 issues | ✅ 0 issues | ✅ 0 issues | ✅ 0 issues |
| go build | ✅ | ✅ | ✅ | ✅ |
| go test | ✅ all pass | ✅ all pass | ✅ all pass | ✅ all pass |

## Out of Scope

- 不自动升级用户本地 golangci-lint（文档给命令，开发者自行执行）
- pre-commit / CLAUDE.md 循环缺 go-auth（CI matrix 已覆盖，建议另开 issue）

Closes #32