### PR TITLE
chore(deps): normalize go directive to 1.26.5, align jwt/v5 & atomic, replace polaris-go RC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache-dependency-path: ${{ matrix.module }}/go.sum
 
       - name: go build
@@ -44,6 +44,10 @@ jobs:
         with:
           version: v2.12.2
           args: --timeout=5m ./${{ matrix.module }}/...
+
+      - name: go mod tidy check
+        working-directory: ${{ matrix.module }}
+        run: go mod tidy -diff
 
       - name: upload coverage
         if: success() || failure()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/setup-go@v5
         if: steps.match.outputs.matched == 'true'
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache-dependency-path: ${{ matrix.module }}/go.sum
 
       - name: go build

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache-dependency-path: ${{ matrix.module }}/go.sum
 
       - name: install govulncheck
@@ -55,7 +55,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - uses: github/codeql-action/init@v3
         with:

--- a/example/go.mod
+++ b/example/go.mod
@@ -1,6 +1,6 @@
 module github.com/byx-darwin/go-tools/example
 
-go 1.25.8
+go 1.26.5
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.46.0

--- a/go-auth/go.mod
+++ b/go-auth/go.mod
@@ -1,10 +1,11 @@
 module github.com/byx-darwin/go-tools/go-auth
 
-go 1.25.0
+go 1.26.5
 
 require (
 	github.com/byx-darwin/go-tools/go-common v0.0.0
-	github.com/golang-jwt/jwt/v5 v5.3.0
+	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/samber/oops v1.22.0
 	github.com/stretchr/testify v1.11.1
 )
 
@@ -14,7 +15,6 @@ require (
 	github.com/oklog/ulid/v2 v2.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/samber/lo v1.53.0 // indirect
-	github.com/samber/oops v1.22.0 // indirect
 	go.opentelemetry.io/otel v1.44.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	golang.org/x/text v0.38.0 // indirect

--- a/go-auth/go.sum
+++ b/go-auth/go.sum
@@ -2,8 +2,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
-github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=

--- a/go-common/go.mod
+++ b/go-common/go.mod
@@ -1,6 +1,6 @@
 module github.com/byx-darwin/go-tools/go-common
 
-go 1.25.0
+go 1.26.5
 
 require (
 	github.com/dave/dst v0.27.4

--- a/go-framework/go.mod
+++ b/go-framework/go.mod
@@ -1,6 +1,6 @@
 module github.com/byx-darwin/go-tools/go-framework
 
-go 1.25.8
+go 1.26.5
 
 require (
 	github.com/bytedance/gopkg v0.1.4
@@ -10,7 +10,7 @@ require (
 	github.com/cloudwego/kitex v0.16.2
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0
-	github.com/polarismesh/polaris-go v1.7.1-rc3
+	github.com/polarismesh/polaris-go v1.7.1
 	github.com/samber/oops v1.22.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.69.0
@@ -83,7 +83,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
-	go.uber.org/atomic v1.9.0 // indirect
+	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/arch v0.28.0 // indirect

--- a/go-framework/go.sum
+++ b/go-framework/go.sum
@@ -444,8 +444,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/polarismesh/polaris-go v1.7.1-rc3 h1:VVptKn2eM7f5x49PutM76JBZ7LBhCKsY4rc8VEnByzs=
-github.com/polarismesh/polaris-go v1.7.1-rc3/go.mod h1:eUS1Ssh/MDutg42b/Z9o8VlXFwgFF6+zeOPaOy5RGmo=
+github.com/polarismesh/polaris-go v1.7.1 h1:JRLy582A2dR4jfmbFPt4lDtsTM1+xuofC4mIXHFDAx0=
+github.com/polarismesh/polaris-go v1.7.1/go.mod h1:eUS1Ssh/MDutg42b/Z9o8VlXFwgFF6+zeOPaOy5RGmo=
 github.com/polarismesh/specification v1.8.0 h1:k112R8eUZfdv1tVthWcf5AbE0SR/afyETz6Eii5OFw8=
 github.com/polarismesh/specification v1.8.0/go.mod h1:Gb9OLXOELG4VwhxPh4DK6C0C3Z7FFYCmVkTW/d6+kvM=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -558,8 +558,8 @@ go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqe
 go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
 go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
-go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
-go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
+go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=

--- a/go-middleware/go.mod
+++ b/go-middleware/go.mod
@@ -1,6 +1,6 @@
 module github.com/byx-darwin/go-tools/go-middleware
 
-go 1.25.0
+go 1.26.5
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.46.0

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.25.8
+go 1.26.5
 
 use (
 	./example

--- a/go.work.sum
+++ b/go.work.sum
@@ -1453,8 +1453,6 @@ github.com/cloudwego/prutal v0.1.0 h1:fdnKk+w+VMbUoMvocuxpIteC6Haa1/a32c7SZxJr0v
 github.com/cloudwego/prutal v0.1.0/go.mod h1:PHt8jxqWkVFv7VcXGVy5IJA/6CTbAtagHZGwCfNSMVA=
 github.com/cloudwego/prutal v0.1.1 h1:ie4PBf4sqJewL5ZgZwWVFplx9vypNG03BWj5VGlEFg8=
 github.com/cloudwego/prutal v0.1.1/go.mod h1:PHt8jxqWkVFv7VcXGVy5IJA/6CTbAtagHZGwCfNSMVA=
-github.com/cloudwego/prutal v0.1.3 h1:Q0FeohplP/TuvdQqKsBn0BiPdqdE8nQZXc/XXl3HycY=
-github.com/cloudwego/prutal v0.1.3/go.mod h1:PHt8jxqWkVFv7VcXGVy5IJA/6CTbAtagHZGwCfNSMVA=
 github.com/cloudwego/thriftgo v0.3.6/go.mod h1:29ukiySoAMd0vXMYIduAY9dph/7dmChvOS11YLotFb8=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4 h1:hzAQntlaYRkVSFEfj9OTWlVV1H155FMD8BTKktLv0QI=
 github.com/cncf/udpa/go v0.0.0-20220112060539-c52dc94e7fbe h1:QQ3GSy+MqSHxm/d8nCtnAiZdYFd45cYZPs8vOOIYKfk=
@@ -1810,9 +1808,12 @@ github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30 h1:BHT1/DKsYDGkUgQ2
 github.com/performancecopilot/speed/v4 v4.0.0 h1:VxEDCmdkfbQYDlcr/GC9YoN9PQ6p8ulk9xVsepYy9ZY=
 github.com/pierrec/lz4/v4 v4.1.25/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e h1:aoZm08cpOy4WuID//EZDgcC4zIxODThtZNPirFr42+A=
+github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/profile v1.2.1 h1:F++O52m40owAmADcojzM+9gyjmMOY/T4oYJkgFDH8RE=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
+github.com/polarismesh/polaris-go v1.7.1 h1:JRLy582A2dR4jfmbFPt4lDtsTM1+xuofC4mIXHFDAx0=
+github.com/polarismesh/polaris-go v1.7.1/go.mod h1:eUS1Ssh/MDutg42b/Z9o8VlXFwgFF6+zeOPaOy5RGmo=
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
@@ -1829,6 +1830,7 @@ github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlT
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
 github.com/rogpeppe/fastuuid v1.2.0 h1:Ppwyp6VYCF1nvBTXL3trRso7mXMlRrw9ooo375wvi2s=
 github.com/rogpeppe/go-internal v1.3.0 h1:RR9dF3JtopPvtkroDZuVD7qquD0bnHlKSqaQhgwt8yk=
+github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f h1:UFr9zpz4xgTnIE5yIMtWAMngCdZ9p/+q6lTbgelo80M=
@@ -2214,6 +2216,7 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20250428153025-10db94c68c34/go.
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250519155744-55703ea1f237/go.mod h1:qQ0YXyHHx3XkvlzUtpXDkS29lDSafHMZBAZDc03LQ3A=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260523011958-0a33c5d7ca68/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260610212136-7ab31c22f7ad/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/grpc v1.54.0/go.mod h1:PUSEXI6iWghWaB6lXM4knEgpJNu2qUcKfDtNci3EC2g=
 google.golang.org/grpc v1.59.0/go.mod h1:aUPDwccQo6OTjy7Hct4AfBPD1GptF4fyUjIkQ9YtF98=
 google.golang.org/grpc v1.61.0/go.mod h1:VUbo7IFqmF1QtCAstipjG0GIoq49KvMe9+h1jFLBNJs=


### PR DESCRIPTION
## Summary

对齐各模块依赖版本，消除 go 指令分裂、跨模块版本漂移与 polaris-go 预发布锁定；`go mod tidy` 修正 go-auth 的 oops 误标。均为一致性修复，不改运行行为。

属于审计跟踪 issue #34 的 **Phase 0 — 零风险快速修复**。

## Changes

| 项 | 之前 | 之后 |
|----|------|------|
| go 指令 | go-common/go-auth/go-middleware `1.25.0`；go-framework/example/go.work `1.25.8` | 统一 `1.26.5` |
| `golang-jwt/jwt/v5` | go-auth `v5.3.0` | `v5.3.1`（与 go-framework/example 对齐） |
| `go.uber.org/atomic` | go-framework `v1.9.0` | `v1.11.0`（与 go-middleware/example 对齐） |
| `polarismesh/polaris-go` | go-framework `v1.7.1-rc3`（RC） | 稳定版 `v1.7.1` |
| `samber/oops` (go-auth) | 直接 import 但标 `// indirect` | `go mod tidy` 提升为 direct require |
| CI `go-version` | `1.25` | `1.26`（ci/release/security 三个 workflow） |
| CI 防复发门禁 | 无 | ci.yml 新增 `go mod tidy -diff` 检查 |

> 注：go 指令目标版本经讨论由 issue 原定的 1.25.8 调整为 **1.26.5**（本地工具链即 go1.26.5，GOTOOLCHAIN=auto）。

## Verification

- [x] `go build ./go-common/... ./go-auth/... ./go-middleware/... ./go-framework/...`（含 example）通过
- [x] `go vet` 全模块通过
- [x] `go mod verify` 四模块全部 `all modules verified`
- [x] `go test ... -count=1` 全部通过
- [x] `golangci-lint run`（v2.12.2）四模块 0 issues
- [x] `go mod tidy -diff` 四模块 CLEAN

Closes #31
