### PR TITLE
docs: correct module dependency diagram to real DAG topology (go-framework ⊥ go-middleware)

### DIFF
--- a/.claude/rules/go.md
+++ b/.claude/rules/go.md
@@ -47,7 +47,7 @@ Current modules are being reorganized into three libraries (see `specs/02_split_
 |---------------|---------------|-----------------|
 | `tools/` | `go-common` | Zero framework dependency |
 | `middleware/` | `go-middleware` | No Hertz/Kitex dependency |
-| `config/`, `hertz/`, `kitex/` | `go-framework` | Depends on go-common + go-middleware |
+| `config/`, `hertz/`, `kitex/` | `go-framework` | Depends on go-common + go-auth (sibling of go-middleware) |
 
 When adding new code, place it according to these rules:
 - Pure utilities (crypto, cache, time, net) → go-common tier

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,14 +11,18 @@ The 5-module → 3-library split (2026-06-23) is **complete**. ncgo generated pr
 ### Structure
 
 ```text
-go-common          ← 最底层，零框架依赖 (crypto, cache, httpclient, log, timeutil, netutil, captcha, error)
-    ↑
-go-auth            ← 认证工具 (JWT, Session/Device 接口, 错误码)
-    ↑
-go-middleware       ← 中间件客户端 (redis, kafka, db, es, clickhouse, tls, auth)
-    ↑
-go-framework        ← 框架适配 (hertz, kitex, config)
+                    go-common    ← 最底层，零框架依赖
+                        ↑          (crypto, cache, httpclient, log, timeutil, netutil, captcha, error)
+                     go-auth       ← 认证工具 (JWT, Session/Device 接口, 错误码)
+                    ↑       ↑
+          ┌─────────┘       └─────────┐
+    go-middleware                  go-framework
+    中间件客户端                    框架适配 (hertz, kitex, config)
+    (redis, kafka, db,
+     es, clickhouse, tls, auth)
 ```
+
+> 真实拓扑是 **DAG，非线性链**：`go-framework` 与 `go-middleware` 为**兄弟关系**（sibling），二者均依赖 `go-auth` + `go-common`，彼此**无依赖**。
 
 | Module | Import Path | Purpose |
 |--------|------------|---------|
@@ -118,7 +122,7 @@ go-middleware/             → Middleware clients (no Hertz/Kitex dependency)
   es/                      → Elasticsearch client
   clickhouse/              → ClickHouse client
   tls/                     → TLS connection setup (火山引擎)
-go-framework/              → Framework adapters (depends on go-common + go-middleware)
+go-framework/              → Framework adapters (depends on go-common + go-auth; sibling of go-middleware)
   hertz/                   → Hertz HTTP server, response helpers, middleware
   hertz/observability/     → OTel Tracing + Metrics (W3C + B3 propagator, runtime metrics)
   kitex/                   → Kitex RPC options, discovery, registry, rpcerror
@@ -136,9 +140,11 @@ specs/                     → Strategic planning documents
 Each sub-module has its own `go.mod`. Cross-module dependencies use `github.com/byx-darwin/go-tools/<module>` import paths and are declared in `go.work`. Do not create circular dependencies between modules.
 
 ### Dependency hierarchy
-- **go-common**: zero framework dependency, pure utility — does not import go-middleware or go-framework
-- **go-middleware**: middleware clients — may import go-common, must NOT import go-framework
-- **go-framework**: Hertz/Kitex adapters — may import go-common and go-middleware
+The four libraries form a **DAG, not a linear chain**. `go-framework` and `go-middleware` are **siblings** — both consume `go-auth` + `go-common`, and neither depends on the other.
+- **go-common**: zero framework dependency, pure utility — does not import any other library
+- **go-auth**: auth utilities — may import go-common only
+- **go-middleware**: middleware clients — may import go-common and go-auth, must NOT import go-framework
+- **go-framework**: Hertz/Kitex adapters — may import go-common and go-auth, must NOT import go-middleware (siblings)
 
 ### ncgo alignment
 - **Config structs**: go-tools structs are the "source of truth", ncgo templates import them

--- a/README.md
+++ b/README.md
@@ -5,12 +5,18 @@ Go microservice toolkits — Hertz / Kitex project infrastructure.
 ## Architecture
 
 ```
-go-common          ← Zero-dependency utility libraries
-    ↑
-go-middleware      ← Middleware clients (Redis / Kafka / DB / ES / CH / TLS)
-    ↑
-go-framework       ← Hertz / Kitex framework adapters (Config / Server / Option / Observability)
+                go-common    ← Zero-dependency utility libraries
+                    ↑
+                 go-auth      ← Auth utilities (JWT / Session / Device)
+                ↑       ↑
+      ┌─────────┘       └─────────┐
+go-middleware                  go-framework
+Middleware clients             Hertz / Kitex framework adapters
+(Redis / Kafka / DB /          (Config / Server / Option /
+ ES / CH / TLS)                 Observability)
 ```
+
+> Real topology is a **DAG**: `go-framework` and `go-middleware` are **siblings** — both depend on `go-auth` + `go-common`, and neither depends on the other.
 
 ## Modules
 

--- a/specs/00_overview.md
+++ b/specs/00_overview.md
@@ -10,13 +10,18 @@
 ## 二、架构
 
 ```text
-go-common          ← 最底层，零框架依赖
-    ↑                 (cache, log, captcha, errcode, netutil, crypto, httpclient, timeutil)
-go-middleware       ← 中间件客户端
-    ↑                 (redis, kafka, db, es, clickhouse, tls)
-go-framework        ← 框架适配
-                      (hertz, kitex, config, observability, accesslog, rpcerror)
+                    go-common    ← 最底层，零框架依赖
+                        ↑          (cache, log, captcha, errcode, netutil, crypto, httpclient, timeutil)
+                     go-auth       ← 认证工具 (JWT, Session/Device)
+                    ↑       ↑
+          ┌─────────┘       └─────────┐
+    go-middleware                  go-framework
+    中间件客户端                    框架适配
+    (redis, kafka, db,             (hertz, kitex, config,
+     es, clickhouse, tls)           observability, accesslog, rpcerror)
 ```
+
+> 真实拓扑是 **DAG**：`go-framework` 与 `go-middleware` 为**兄弟关系**，二者均依赖 `go-auth` + `go-common`，彼此无依赖。
 
 ## 三、各库职责
 

--- a/specs/01_split_plan_summary.md
+++ b/specs/01_split_plan_summary.md
@@ -21,12 +21,17 @@ go-tools/                     (go workspace)
 ## 二、目标结构（三层）
 
 ```text
-go-common          ← 最底层，零框架依赖
-    ↑
-go-middleware       ← 中间件客户端（Redis / Kafka / DB）
-    ↑
-go-framework        ← 框架适配（Hertz / Kitex + 配置）
+              go-common    ← 最底层，零框架依赖
+                  ↑
+               go-auth      ← 认证工具
+              ↑       ↑
+    ┌─────────┘       └─────────┐
+go-middleware              go-framework
+中间件客户端                框架适配
+（Redis / Kafka / DB）      （Hertz / Kitex + 配置）
 ```
+
+> 真实拓扑是 **DAG**：`go-framework` 与 `go-middleware` 为**兄弟关系**，二者均依赖 `go-auth` + `go-common`，彼此无依赖。
 
 ## 三、模块归属
 

--- a/specs/01_split_plan_summary.md
+++ b/specs/01_split_plan_summary.md
@@ -83,7 +83,7 @@ go-framework        ← 框架适配（Hertz / Kitex + 配置）
 | — | `go-framework/kitex/middleware/accesslog.go` | Kitex Access Log 中间件（结构化 JSON 日志） |
 | — | `go-framework/hertz/middleware/accesslog.go` | Hertz Access Log 中间件（结构化 JSON 日志） |
 
-**依赖**：go-common + go-middleware + `hertz` + `kitex` + `polaris-go`
+**依赖**：go-common + go-auth + `hertz` + `kitex` + `polaris-go`
 
 ## 四、导入路径变化
 

--- a/specs/03_implementation_phases.md
+++ b/specs/03_implementation_phases.md
@@ -152,7 +152,7 @@ Phase 1 (go-common)
     ↓
 Phase 2 (go-middleware) ──→ 需要 go-common
     ↓
-Phase 3 (go-framework)  ──→ 需要 go-common + go-middleware ✓ 已完成
+Phase 3 (go-framework)  ──→ 需要 go-common + go-auth ✓ 已完成
     ↓
     ↓
 Phase 5 (验证 + 文档)


### PR DESCRIPTION
## Summary

修正文档中的模块依赖描述，使其反映**真实 DAG 拓扑**：`go-framework` 与 `go-middleware` 是**兄弟关系**，而非线性链 `go-middleware ← go-framework`。

## Why

`CLAUDE.md` 及多个 `specs/` 文档描述的线性依赖链在代码中并不存在。经 `go.mod` 实证：

- `go-framework` 依赖 `go-auth` + `go-common`，**不依赖 `go-middleware`**
- `go-framework` 实际导入：`go-auth/{device,jwt,session}` + `go-common/{error,log,netutil}`
- `go-middleware` 与 `go-framework` 均消费 `go-auth` + `go-common`，彼此无依赖

```
go-common ← go-auth ─┬─← go-middleware
                     └─← go-framework   (二者为兄弟)
```

## Changes（纯文档，无代码改动）

| 文件 | 修正 |
|------|------|
| `CLAUDE.md` | Structure 图改为 DAG + 兄弟关系说明；Workspace Layout 行；Dependency hierarchy bullets |
| `specs/00_overview.md` | 架构图改为 DAG（补入 `go-auth` 节点）+ 兄弟关系说明 |
| `specs/01_split_plan_summary.md` | go-framework 依赖行：`go-middleware` → `go-auth` |
| `specs/03_implementation_phases.md` | Phase 3 注释：`需要 go-common + go-middleware` → `go-common + go-auth` |
| `.claude/rules/go.md` | Dependency-rule 表格行同步修正（同一事实错误） |

## Validation

- 全仓 grep：残留的 "go-framework 依赖 go-middleware" 声明 = **0**
- `go build` + `go vet` 四模块全部通过（文档改动不影响构建，作为标准门禁运行）

## Notes

- 是否让 `go-framework` 消费 `go-middleware`（接线）属架构决策，按 #33 AC#4 **另开 issue 跟踪**，本 PR 不涉及。
- 相邻文档缺口（`specs/00_overview.md` 缺 `go-auth` 职责小节、包名 `errcode`/`error` 漂移）非本 issue 范围，未改动。
- 关联跟踪 issue：#34（Phase 0 收尾项）。

Closes #33
