### PR TITLE
docs: fill adjacent doc accuracy gaps (go-auth rows, errcode→error, package lists, AES)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ go.work                    → Workspace root (go 1.25.8)
 go-common/                 → Zero-dependency utilities
   cache/                   → Generic cache (samber/hot wrapper): LRU/LFU/FIFO/TwoQueue/ARC
   captcha/                 → CAPTCHA generation with cache
-  crypto/                  → Encryption (MD5/SHA/HMAC/AES/TEA)
+  crypto/                  → Encryption (MD5/SHA/HMAC/TEA)
   httpclient/              → HTTP client with retry, m3u8 support
   log/                     → Structured logging (slog + lumberjack + OTel)
   netutil/                 → Network utilities

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Middleware clients             Hertz / Kitex framework adapters
 
 | Module | Purpose | Install |
 |--------|--------|---------|
-| [go-common](./go-common) | Utilities: crypto / cache / log / netutil / timeutil / httpclient / captcha / auth / templateutil / executil / astutil | `go get github.com/byx-darwin/go-tools/go-common` |
+| [go-common](./go-common) | Utilities: crypto / cache / log / error / netutil / timeutil / httpclient / captcha / auth / templateutil / executil / astutil | `go get github.com/byx-darwin/go-tools/go-common` |
+| [go-auth](./go-auth) | Auth utilities: jwt (Sign/Verify/Refresh) / session / device / error | `go get github.com/byx-darwin/go-tools/go-auth` |
 | [go-middleware](./go-middleware) | Middleware clients: redis / kafka / db / es / clickhouse / tls | `go get github.com/byx-darwin/go-tools/go-middleware` |
 | [go-framework](./go-framework) | Framework adapters: hertz / kitex / config / observability / accesslog / rpcerror | `go get github.com/byx-darwin/go-tools/go-framework` |
 

--- a/specs/00_overview.md
+++ b/specs/00_overview.md
@@ -5,13 +5,13 @@
 
 ## 一、项目定位
 
-**go-tools** 是 Hertz/Kitex 微服务共享基础设施库，提供配置、日志、中间件客户端、错误处理等通用能力。三个独立库按依赖层级组织。
+**go-tools** 是 Hertz/Kitex 微服务共享基础设施库，提供配置、日志、中间件客户端、错误处理等通用能力。四个独立库（go-common / go-auth / go-middleware / go-framework）按依赖 DAG 组织。
 
 ## 二、架构
 
 ```text
                     go-common    ← 最底层，零框架依赖
-                        ↑          (cache, log, captcha, errcode, netutil, crypto, httpclient, timeutil)
+                        ↑          (cache, log, captcha, error, netutil, crypto, httpclient, timeutil)
                      go-auth       ← 认证工具 (JWT, Session/Device)
                     ↑       ↑
           ┌─────────┘       └─────────┐
@@ -31,7 +31,7 @@
 |---|------|
 | `cache` | 泛型缓存（基于 samber/hot，支持 FIFO/LRU/LFU/CLOCK/MRU + TTL） |
 | `captcha` | 验证码生成与校验（图片验证码 + 数字/字母码 + CacheStore） |
-| `errcode` | 统一错误码定义（10000-59999）+ HTTP 状态码映射 |
+| `error` | 统一错误码定义（10000-59999）+ HTTP 状态码映射 |
 | `log` | 结构化日志（基于 slog + OTel TraceID/SpanID + 文件轮转） |
 | `log/adapters` | Hertz/Kitex 日志适配器 |
 | `netutil` | 网络工具（内网 IP 获取） |
@@ -39,6 +39,18 @@
 | `httpclient` | HTTP 客户端（重试/M3U8） |
 | `auth` | AK/SK 生成 |
 | `timeutil` | 时间工具 |
+| `astutil` | Go AST 操作库（基于 dave/dst，代码生成辅助） |
+| `executil` | 增强的命令执行包装器 |
+| `templateutil` | 可插拔的模板辅助函数库 |
+
+### go-auth
+
+| 包 | 职责 |
+|---|------|
+| `jwt` | 泛型 JWT 签发/验证/刷新（基于 golang-jwt/jwt/v5，Sign/Verify/Refresh） |
+| `session` | 会话存储契约（Session 结构体 + Store 接口） |
+| `device` | 设备会话管理契约（Device 结构体 + Store 接口） |
+| `error` | 认证错误码与预定义错误构造器（40000-40099，包名 autherror） |
 
 ### go-middleware
 
@@ -94,7 +106,7 @@ go-middleware  20000-20699  ── redis/kafka/db/es/ch/tls/obs
   40310-40314  状态（AccountDisabled/OrderInvalid/BalanceInsufficient/VerificationFailed/OperationDenied）
 ```
 
-详见 `go-common/errcode/code.go` 和 `go-framework/kitex/rpcerror/error.go`。
+详见 `go-common/error/error.go` 和 `go-framework/kitex/rpcerror/error.go`。
 
 ## 五、关键技术决策
 


### PR DESCRIPTION
> ⚠️ **Stacked PR** — 基于 `feat/33-docs-dag`（#39）。请先合并 #39，再将本 PR base 改为 `main` 合并。本 PR 仅含相邻文档缺口的增量 diff。

## Summary

#33 修复后的核实扫描发现的**相邻文档准确性缺口**，逐项对照代码核实后修正。纯文档，无代码改动。

## Changes（已核实）

**`specs/00_overview.md`**
- 新增 `go-auth` 职责小节（`jwt` / `session` / `device` / `error`，对照 `go-auth/*` 包注释）
- go-common 表：`errcode` → `error`（真实包名）；补齐缺失的 `astutil` / `executil` / `templateutil`
- 图注 `errcode` → `error`；错误码文件路径 `go-common/errcode/code.go` → `go-common/error/error.go`（真实路径，`error.go` 定义 10000+ 码段）
- "三个独立库" → "四个独立库"（与 CLAUDE.md "four independently versioned libraries" 及现实 4 模块一致）

**`README.md`**
- Modules 表新增 `go-auth` 行
- go-common 用途列表补 `error`

**`CLAUDE.md`**
- `crypto` 描述 `MD5/SHA/HMAC/AES/TEA` → `MD5/SHA/HMAC/TEA`（代码无 AES，`go-common/crypto/` 仅 `encrypt.go`+`tea.go`；AES-GCM 为待实施的 #25）

## Verification
- 真实结构核实：go-common 12 子包、go-auth 4 子包、crypto 仅 MD5/SHA/HMAC+TEA（无 AES）
- 全仓 grep：docs 中 `errcode` = 0；CLAUDE.md 中 `AES` = 0
- `go build` + `go vet` 四模块通过

## Notes
- 关联：#33（依赖拓扑）、#34（工程卫生跟踪）、#25（未来 AES-GCM）

Closes #40
