### PR TITLE
fix(go-auth): pin JWT signing method and add default expiration (#19, #20)

### DIFF
--- a/go-auth/jwt/options.go
+++ b/go-auth/jwt/options.go
@@ -23,21 +23,34 @@ import (
 // defaultSigningMethod 默认签名算法。
 var defaultSigningMethod = gojwt.SigningMethodHS256
 
+const (
+	// defaultExpiration 默认 Token 过期时间（2 小时）。
+	defaultExpiration = 2 * time.Hour
+)
+
 // config 存储 JWT 配置选项。
+// expiration 为指针类型以区分"未显式设置"（nil，使用默认 2h）
+// 与"显式覆盖"（非 nil，覆盖 Claims 自带值）。
+// ignoreClaimsExpiration 仅在 Refresh 路径为 true，表示忽略 Claims 自带的
+// ExpiresAt，强制以默认或显式 expiration 重新设定（Refresh 语义：新 Token
+// 使用新的过期时间，不复用旧 Token 的剩余有效期）。
 type config struct {
-	expiration    time.Duration
-	issuer        string
-	signingMethod gojwt.SigningMethod
+	expiration             *time.Duration
+	issuer                 string
+	signingMethod          gojwt.SigningMethod
+	ignoreClaimsExpiration bool
 }
 
 // Option 定义配置选项函数。
 type Option func(*config)
 
-// WithExpiration 设置 JWT 过期时间。零值忽略。
+// WithExpiration 设置 JWT 过期时间。默认 2 小时。
+// 显式传入正值覆盖默认（并覆盖 Claims 自带的 ExpiresAt）；
+// 零值或负值被忽略，保留默认。
 func WithExpiration(d time.Duration) Option {
 	return func(c *config) {
 		if d > 0 {
-			c.expiration = d
+			c.expiration = &d
 		}
 	}
 }
@@ -61,7 +74,16 @@ func WithSigningMethod(method gojwt.SigningMethod) Option {
 	}
 }
 
+// withIgnoreClaimsExpiration 内部选项，供 Refresh 使用：
+// 强制忽略 Claims 自带的 ExpiresAt，以默认或显式 expiration 重新设定。
+func withIgnoreClaimsExpiration() Option {
+	return func(c *config) {
+		c.ignoreClaimsExpiration = true
+	}
+}
+
 // applyOptions 应用选项并返回配置快照。
+// 默认值：signingMethod = HS256；expiration = nil（由 setClaimsDefaults 按 2h 默认处理）。
 func applyOptions(opts []Option) config {
 	cfg := config{
 		signingMethod: defaultSigningMethod,

--- a/go-auth/jwt/token.go
+++ b/go-auth/jwt/token.go
@@ -14,7 +14,8 @@ import (
 
 // Sign 签发 JWT，支持任意 Claims 类型。
 // claims 必须实现 jwt.Claims 接口（通常通过嵌入 jwt.RegisteredClaims）。
-// 当 opts 中设置了 WithExpiration 时，自动设置 ExpiresAt。
+// 默认过期时间为 2 小时，可通过 WithExpiration 覆盖；
+// 若 Claims 已自带 ExpiresAt，则优先保留 Claims 中的显式值。
 // 当 opts 中设置了 WithIssuer 时，自动设置 Issuer。
 func Sign[T any](claims T, secret []byte, opts ...Option) (string, error) {
 	cfg := applyOptions(opts)
@@ -79,7 +80,8 @@ func Verify[T any](tokenStr string, secret []byte, opts ...Option) (*T, error) {
 
 // Refresh 刷新 JWT（延长过期时间，保留原有 Claims 数据）。
 // 先验证原 Token 有效性，再使用新选项重新签发。
-// 原 Claims 中的 ExpiresAt、Issuer 等会被 opts 中的值覆盖。
+// 原 Claims 中的 ExpiresAt、Issuer 等会被 opts 中的值覆盖；
+// 未显式指定 WithExpiration 时，使用默认 2 小时过期。
 func Refresh[T any](tokenStr string, secret []byte, opts ...Option) (string, error) {
 	// 先验证原 Token，提取 Claims。opts 透传给 Verify 以复用签名算法校验。
 	claims, err := Verify[T](tokenStr, secret, opts...)
@@ -89,19 +91,34 @@ func Refresh[T any](tokenStr string, secret []byte, opts ...Option) (string, err
 			Wrap(err)
 	}
 
-	// 使用原 Claims 重新签发，应用新选项。
-	return Sign(*claims, secret, opts...)
+	// Refresh 语义：新 Token 不复用旧 Token 的剩余有效期，强制刷新 ExpiresAt。
+	signOpts := append([]Option{withIgnoreClaimsExpiration()}, opts...)
+	return Sign(*claims, secret, signOpts...)
 }
 
 // setClaimsDefaults 根据配置设置 Claims 的默认字段。
+//   - Sign 路径（ignoreClaimsExpiration == false）：
+//     若未显式指定 expiration，仅在 Claims 未自带 ExpiresAt 时以默认 2h 填充，
+//     保留调用方在 Claims 中显式设置的过期时间。
+//   - Refresh 路径（ignoreClaimsExpiration == true）：
+//     忽略 Claims 自带的 ExpiresAt，总是以默认 2h 或显式 WithExpiration 重新设定，
+//     保证新 Token 不复用旧 Token 的剩余有效期。
 func setClaimsDefaults(claims gojwt.Claims, cfg config) {
 	rc := extractRegisteredClaims(claims)
 	if rc == nil {
 		return
 	}
 
-	if cfg.expiration > 0 {
-		rc.ExpiresAt = gojwt.NewNumericDate(time.Now().Add(cfg.expiration))
+	switch {
+	case cfg.expiration != nil:
+		// 显式 WithExpiration 覆盖一切。
+		rc.ExpiresAt = gojwt.NewNumericDate(time.Now().Add(*cfg.expiration))
+	case cfg.ignoreClaimsExpiration:
+		// Refresh 路径：强制刷新为默认 2h。
+		rc.ExpiresAt = gojwt.NewNumericDate(time.Now().Add(defaultExpiration))
+	case rc.ExpiresAt == nil:
+		// Sign 默认路径：Claims 未自带 ExpiresAt 时填充默认。
+		rc.ExpiresAt = gojwt.NewNumericDate(time.Now().Add(defaultExpiration))
 	}
 
 	if cfg.issuer != "" {

--- a/go-auth/jwt/token.go
+++ b/go-auth/jwt/token.go
@@ -2,6 +2,7 @@ package jwt
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"time"
 
@@ -41,8 +42,11 @@ func Sign[T any](claims T, secret []byte, opts ...Option) (string, error) {
 
 // Verify 验证 JWT，返回指定类型的 Claims 指针。
 // 验证失败时返回认证错误（TokenInvalid 或 TokenExpired）。
-func Verify[T any](tokenStr string, secret []byte) (*T, error) {
+// 支持通过 opts 指定期望的签名算法（默认 HS256），防止算法混淆攻击。
+// 使用 WithSigningMethod 覆盖默认算法（如 RS256、ES256）。
+func Verify[T any](tokenStr string, secret []byte, opts ...Option) (*T, error) {
 	var zero T
+	cfg := applyOptions(opts)
 
 	// 通过 any 进行运行时接口检查。
 	claims, ok := any(&zero).(gojwt.Claims)
@@ -52,7 +56,11 @@ func Verify[T any](tokenStr string, secret []byte) (*T, error) {
 			Errorf("claims type %T does not implement jwt.Claims", zero)
 	}
 
-	token, err := gojwt.ParseWithClaims(tokenStr, claims, func(_ *gojwt.Token) (any, error) {
+	token, err := gojwt.ParseWithClaims(tokenStr, claims, func(tok *gojwt.Token) (any, error) {
+		// 验证签名算法，防止算法混淆攻击（如 RS256→HS256）。
+		if tok.Method != cfg.signingMethod {
+			return nil, fmt.Errorf("unexpected signing method: got %v, want %v", tok.Header["alg"], cfg.signingMethod.Alg())
+		}
 		return secret, nil
 	})
 	if err != nil {
@@ -73,8 +81,8 @@ func Verify[T any](tokenStr string, secret []byte) (*T, error) {
 // 先验证原 Token 有效性，再使用新选项重新签发。
 // 原 Claims 中的 ExpiresAt、Issuer 等会被 opts 中的值覆盖。
 func Refresh[T any](tokenStr string, secret []byte, opts ...Option) (string, error) {
-	// 先验证原 Token，提取 Claims。
-	claims, err := Verify[T](tokenStr, secret)
+	// 先验证原 Token，提取 Claims。opts 透传给 Verify 以复用签名算法校验。
+	claims, err := Verify[T](tokenStr, secret, opts...)
 	if err != nil {
 		return "", oops.With("jwt.Refresh").
 			Code(autherror.CodeJWTRefreshFailed).

--- a/go-auth/jwt/token_test.go
+++ b/go-auth/jwt/token_test.go
@@ -64,7 +64,8 @@ func TestSignWithCustomSigningMethod(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	parsed, err := Verify[UserClaims](token, testSecret)
+	// 签发与验证必须使用相同的签名算法，否则方法不匹配会被拒绝。
+	parsed, err := Verify[UserClaims](token, testSecret, WithSigningMethod(gojwt.SigningMethodHS512))
 	require.NoError(t, err)
 	assert.Equal(t, "user-789", parsed.UserUUID)
 }
@@ -188,6 +189,80 @@ func TestRefreshWithIssuer(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "new-issuer", parsed.Issuer)
 	assert.Equal(t, "user-issuer-refresh", parsed.UserUUID)
+}
+
+func TestVerifyWithExplicitSigningMethod(t *testing.T) {
+	claims := UserClaims{UserUUID: "user-hs512-explicit"}
+
+	// 用 HS512 签发。
+	token, err := Sign(claims, testSecret,
+		WithExpiration(time.Hour),
+		WithSigningMethod(gojwt.SigningMethodHS512),
+	)
+	require.NoError(t, err)
+
+	// 显式声明期望 HS512 应当成功，Claims 完整返回。
+	parsed, err := Verify[UserClaims](token, testSecret, WithSigningMethod(gojwt.SigningMethodHS512))
+	require.NoError(t, err)
+	assert.Equal(t, "user-hs512-explicit", parsed.UserUUID)
+}
+
+func TestVerifyAlgorithmConfusion(t *testing.T) {
+	claims := UserClaims{UserUUID: "user-confusion"}
+
+	// 攻击场景：Token 实际用 HS256 签发，但调用方期望 RS256。
+	// keyfunc 必须在任何 RSA/PEM 解析之前拒绝方法不匹配。
+	token, err := Sign(claims, testSecret, WithExpiration(time.Hour))
+	require.NoError(t, err)
+
+	_, err = Verify[UserClaims](token, testSecret, WithSigningMethod(gojwt.SigningMethodRS256))
+	require.Error(t, err)
+
+	code, _ := goerror.Extract(err)
+	assert.Equal(t, autherror.CodeTokenInvalid, code)
+}
+
+func TestVerifyMethodMismatchHS512(t *testing.T) {
+	claims := UserClaims{UserUUID: "user-mismatch"}
+
+	// 用 HS512 签发。
+	token, err := Sign(claims, testSecret,
+		WithExpiration(time.Hour),
+		WithSigningMethod(gojwt.SigningMethodHS512),
+	)
+	require.NoError(t, err)
+
+	// 裸 Verify 默认期望 HS256，HS512 Token 应被拒绝。
+	_, err = Verify[UserClaims](token, testSecret)
+	require.Error(t, err)
+
+	code, _ := goerror.Extract(err)
+	assert.Equal(t, autherror.CodeTokenInvalid, code)
+}
+
+func TestRefreshWithSigningMethod(t *testing.T) {
+	claims := UserClaims{UserUUID: "user-refresh-hs512"}
+
+	// 用 HS512 签发短期 Token。
+	token, err := Sign(claims, testSecret,
+		WithExpiration(30*time.Minute),
+		WithSigningMethod(gojwt.SigningMethodHS512),
+	)
+	require.NoError(t, err)
+
+	// Refresh 透传 WithSigningMethod，验证通过后续签。
+	newToken, err := Refresh[UserClaims](token, testSecret,
+		WithExpiration(24*time.Hour),
+		WithSigningMethod(gojwt.SigningMethodHS512),
+	)
+	require.NoError(t, err)
+	assert.NotEmpty(t, newToken)
+	assert.NotEqual(t, token, newToken)
+
+	// 新 Token 用 HS512 验证通过。
+	parsed, err := Verify[UserClaims](newToken, testSecret, WithSigningMethod(gojwt.SigningMethodHS512))
+	require.NoError(t, err)
+	assert.Equal(t, "user-refresh-hs512", parsed.UserUUID)
 }
 
 // ── Options 防御 ──

--- a/go-auth/jwt/token_test.go
+++ b/go-auth/jwt/token_test.go
@@ -70,17 +70,50 @@ func TestSignWithCustomSigningMethod(t *testing.T) {
 	assert.Equal(t, "user-789", parsed.UserUUID)
 }
 
-func TestSignWithoutExpiration(t *testing.T) {
-	claims := UserClaims{UserUUID: "user-noexp"}
+func TestSignDefaultExpiration(t *testing.T) {
+	// 不传 WithExpiration 时，应自动使用默认过期时间（2h）。
+	claims := UserClaims{UserUUID: "user-default-exp"}
 
 	token, err := Sign(claims, testSecret)
 	require.NoError(t, err)
 
 	parsed, err := Verify[UserClaims](token, testSecret)
 	require.NoError(t, err)
-	assert.Equal(t, "user-noexp", parsed.UserUUID)
-	// 没设过期时间时 ExpiresAt 为 nil。
-	assert.Nil(t, parsed.ExpiresAt)
+	assert.Equal(t, "user-default-exp", parsed.UserUUID)
+	require.NotNil(t, parsed.ExpiresAt)
+	assert.WithinDuration(t, time.Now().Add(2*time.Hour), parsed.ExpiresAt.Time, 5*time.Minute)
+}
+
+func TestSignExplicitExpirationOverridesDefault(t *testing.T) {
+	// 显式 WithExpiration(1h) 应覆盖默认 2h。
+	claims := UserClaims{UserUUID: "user-override-exp"}
+
+	token, err := Sign(claims, testSecret, WithExpiration(time.Hour))
+	require.NoError(t, err)
+
+	parsed, err := Verify[UserClaims](token, testSecret)
+	require.NoError(t, err)
+	require.NotNil(t, parsed.ExpiresAt)
+	assert.WithinDuration(t, time.Now().Add(time.Hour), parsed.ExpiresAt.Time, 5*time.Minute)
+}
+
+func TestSignPreservesExplicitClaimsExpiration(t *testing.T) {
+	// Claims 自带显式 ExpiresAt 时，不应被默认值覆盖。
+	futureTime := time.Now().Add(48 * time.Hour)
+	claims := UserClaims{
+		UserUUID: "user-explicit-claims-exp",
+		RegisteredClaims: gojwt.RegisteredClaims{
+			ExpiresAt: gojwt.NewNumericDate(futureTime),
+		},
+	}
+
+	token, err := Sign(claims, testSecret)
+	require.NoError(t, err)
+
+	parsed, err := Verify[UserClaims](token, testSecret)
+	require.NoError(t, err)
+	require.NotNil(t, parsed.ExpiresAt)
+	assert.WithinDuration(t, futureTime, parsed.ExpiresAt.Time, time.Minute)
 }
 
 // ── Verify 失败场景 ──
@@ -191,6 +224,22 @@ func TestRefreshWithIssuer(t *testing.T) {
 	assert.Equal(t, "user-issuer-refresh", parsed.UserUUID)
 }
 
+func TestRefreshCarriesDefaultExpiration(t *testing.T) {
+	// Refresh 不传 WithExpiration 时，新 Token 也应使用默认 2h。
+	claims := UserClaims{UserUUID: "user-refresh-default"}
+
+	token, err := Sign(claims, testSecret, WithExpiration(time.Hour))
+	require.NoError(t, err)
+
+	newToken, err := Refresh[UserClaims](token, testSecret)
+	require.NoError(t, err)
+
+	parsed, err := Verify[UserClaims](newToken, testSecret)
+	require.NoError(t, err)
+	require.NotNil(t, parsed.ExpiresAt)
+	assert.WithinDuration(t, time.Now().Add(2*time.Hour), parsed.ExpiresAt.Time, 5*time.Minute)
+}
+
 func TestVerifyWithExplicitSigningMethod(t *testing.T) {
 	claims := UserClaims{UserUUID: "user-hs512-explicit"}
 
@@ -268,6 +317,7 @@ func TestRefreshWithSigningMethod(t *testing.T) {
 // ── Options 防御 ──
 
 func TestWithExpirationZeroIgnored(t *testing.T) {
+	// 零值 WithExpiration(0) 被忽略 → 默认 2h 生效。
 	claims := UserClaims{UserUUID: "user-zero-exp"}
 
 	token, err := Sign(claims, testSecret, WithExpiration(0))
@@ -275,10 +325,12 @@ func TestWithExpirationZeroIgnored(t *testing.T) {
 
 	parsed, err := Verify[UserClaims](token, testSecret)
 	require.NoError(t, err)
-	assert.Nil(t, parsed.ExpiresAt)
+	require.NotNil(t, parsed.ExpiresAt)
+	assert.WithinDuration(t, time.Now().Add(2*time.Hour), parsed.ExpiresAt.Time, 5*time.Minute)
 }
 
 func TestWithExpirationNegativeIgnored(t *testing.T) {
+	// 负值 WithExpiration(-time.Hour) 被忽略 → 默认 2h 生效。
 	claims := UserClaims{UserUUID: "user-neg-exp"}
 
 	token, err := Sign(claims, testSecret, WithExpiration(-time.Hour))
@@ -286,7 +338,8 @@ func TestWithExpirationNegativeIgnored(t *testing.T) {
 
 	parsed, err := Verify[UserClaims](token, testSecret)
 	require.NoError(t, err)
-	assert.Nil(t, parsed.ExpiresAt)
+	require.NotNil(t, parsed.ExpiresAt)
+	assert.WithinDuration(t, time.Now().Add(2*time.Hour), parsed.ExpiresAt.Time, 5*time.Minute)
 }
 
 func TestWithIssuerEmptyIgnored(t *testing.T) {

--- a/go-auth/jwt/token_test.go
+++ b/go-auth/jwt/token_test.go
@@ -240,7 +240,27 @@ func TestRefreshCarriesDefaultExpiration(t *testing.T) {
 	assert.WithinDuration(t, time.Now().Add(2*time.Hour), parsed.ExpiresAt.Time, 5*time.Minute)
 }
 
+func TestRefreshExplicitExpirationOverridesDefault(t *testing.T) {
+	// Refresh 显式 WithExpiration(24h) 必须同时覆盖旧 Token 自带的过期时间与默认 2h。
+	claims := UserClaims{UserUUID: "user-refresh-override"}
+
+	// 旧 Token 使用 30 分钟过期（与默认 2h 和新 24h 都不相等，保证三者区分）。
+	token, err := Sign(claims, testSecret, WithExpiration(30*time.Minute))
+	require.NoError(t, err)
+
+	newToken, err := Refresh[UserClaims](token, testSecret, WithExpiration(24*time.Hour))
+	require.NoError(t, err)
+	assert.NotEmpty(t, newToken)
+	assert.NotEqual(t, token, newToken)
+
+	parsed, err := Verify[UserClaims](newToken, testSecret)
+	require.NoError(t, err)
+	require.NotNil(t, parsed.ExpiresAt)
+	assert.WithinDuration(t, time.Now().Add(24*time.Hour), parsed.ExpiresAt.Time, 5*time.Minute)
+}
+
 func TestVerifyWithExplicitSigningMethod(t *testing.T) {
+	// 合法的非默认算法流程，必须在调用方显式 pin 期望方法时继续工作。
 	claims := UserClaims{UserUUID: "user-hs512-explicit"}
 
 	// 用 HS512 签发。
@@ -272,6 +292,7 @@ func TestVerifyAlgorithmConfusion(t *testing.T) {
 }
 
 func TestVerifyMethodMismatchHS512(t *testing.T) {
+	// 默认 pin 为 HS256：HS512 Token 必须被拒绝，防御静默算法降级。
 	claims := UserClaims{UserUUID: "user-mismatch"}
 
 	// 用 HS512 签发。
@@ -290,6 +311,7 @@ func TestVerifyMethodMismatchHS512(t *testing.T) {
 }
 
 func TestRefreshWithSigningMethod(t *testing.T) {
+	// Refresh 将 opts 透传给 Verify，确保非默认签名算法在刷新往返中存活。
 	claims := UserClaims{UserUUID: "user-refresh-hs512"}
 
 	// 用 HS512 签发短期 Token。


### PR DESCRIPTION
## Summary

go-auth JWT 安全加固（跟踪 issue #34 · Phase 1 安全加固 · 组 A — JWT）。两处安全修复，同一包 `go-auth/jwt`，按路线图一起做。

## #19 — 固定 JWT 验签算法，防算法混淆（priority:high）

`Verify` 的 keyfunc 此前忽略 `token.Method`：使用非对称签名（RS256/ES256）并以公钥字节作 `secret` 验签时，攻击者若知道公钥，可伪造 `alg=HS256` token 并以公钥字节做 HMAC 签名通过验证（经典 RS→HS 算法混淆）。

**修复：**
- `Verify` 增加向后兼容的可变参数：`Verify[T any](tokenStr string, secret []byte, opts ...Option)`，现有两参数调用点无需改动
- keyfunc 内校验 `token.Method` 与期望签名方法一致（默认 HS256 = `defaultSigningMethod`，可用既有 `WithSigningMethod` 覆盖）；该检查先于任何密码学运算 / PEM 解析执行
- 算法不匹配错误经既有 `mapJWTError` 映射为 `ErrTokenInvalid`（`CodeTokenInvalid`，40001），未新增错误码
- `Refresh` 将 opts 透传给内部 `Verify`，非默认算法在刷新往返中继续工作

## #20 — JWT 默认过期时间

此前不传 `WithExpiration` 时签发的 token 永不过期（footgun，长期有效且无法撤销的凭据）。

**修复：**
- 新增包级常量 `defaultExpiration = 2 * time.Hour`（未导出），`applyOptions` 默认填充
- 显式 `WithExpiration(d>0)` 仍可覆盖；零值 / 负值忽略（默认值生效）
- `Sign` 路径保留 claims 中显式设置的 `ExpiresAt`（不覆盖）；`Refresh` 路径始终应用新的过期时间（默认或显式），通过未导出内部选项实现，无公开 API 变更
- 更新 `Sign` / `Refresh` / `WithExpiration` godoc 说明默认值

## ⚠️ 下游行为变更说明（ncgo 生成项目注意）

- 使用**非 HS256** 算法签发、却以裸 `Verify(token, secret)` 验签的调用方，现在会收到 `CodeTokenInvalid`。**修复方式**：验签时显式传入 `jwt.WithSigningMethod(...)`（与签发算法一致）。
- 不传 `WithExpiration` 签发的 token 现在默认 2h 过期。需要更长期限请显式传入 `WithExpiration`。
- 默认 HS256 的既有调用方不受影响。

## Validation

- `go test ./go-auth/... -count=1` ✅（jwt 包 26 个测试，含 10 个新增 / 更新：算法混淆、方法不匹配、显式方法、Refresh 透传、默认过期、显式覆盖、claims 保留、Refresh 默认 / 显式过期）
- `go build` / `go vet` 全 workspace ✅
- `gofmt -l` ✅ · `golangci-lint run --timeout=5m ./go-auth/...`（v2.12.2）0 issues ✅
- 全 workspace 测试通过，go-framework / go-middleware 消费方无破坏
- 经完整 TDD（RED→GREEN→REFACTOR）+ 逐任务 spec/quality 审查 + 全分支安全审查通过

## Commits

- `d2b69ac` fix(go-auth): pin signing method in JWT Verify to prevent algorithm confusion (#19)
- `8da78fa` fix(go-auth): add default token expiration to JWT options (#20)
- `022cbd4` test(go-auth): add Refresh expiration-override coverage and why-comments (review)

Closes #19
Closes #20

Part of #34 (Phase 1 · 组 A)
