### PR TITLE
fix(go-framework): harden AK/SK middleware — debug sig echo, signature coverage, timestamp window (#21 #22 #23)

### DIFF
--- a/go-framework/hertz/middleware/auth.go
+++ b/go-framework/hertz/middleware/auth.go
@@ -6,9 +6,9 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
-	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/cloudwego/hertz/pkg/app"
 	"github.com/cloudwego/hertz/pkg/protocol"
@@ -17,20 +17,54 @@ import (
 	goerror "github.com/byx-darwin/go-tools/go-common/error"
 )
 
+// defaultTimestampWindow AK/SK 签名时间戳默认新鲜度窗口（±5 分钟）。
+const defaultTimestampWindow = 5 * time.Minute
+
 // AuthFace 鉴权接口，由业务方实现 AK/SK 查找逻辑。
 type AuthFace interface {
 	GetSk(ctx context.Context, c *app.RequestContext,
 		ak string, timestamp int64) (sk string, isDebug bool, err error)
 }
 
-// Auth 返回 Hertz 鉴权中间件。
-// 验证 X-Signature 头中的签名：Base64Decode(ak=xxx&sign=xxx&t=xxx)
-// 签名算法：HmacSHA256(sk, ak+path+/+t+/+ak) → hex
-func Auth(authFace AuthFace) app.HandlerFunc {
+// authOptions Auth 中间件的可选配置。
+type authOptions struct {
+	timestampWindow time.Duration
+}
+
+// Option Auth 中间件配置选项函数。
+type Option func(*authOptions)
+
+// WithTimestampWindow 设置时间戳新鲜度窗口（±window）。
+// window <= 0 时忽略，保持默认 5 分钟。
+func WithTimestampWindow(window time.Duration) Option {
+	return func(o *authOptions) {
+		if window > 0 {
+			o.timestampWindow = window
+		}
+	}
+}
+
+// Auth 返回 Hertz AK/SK 鉴权中间件。
+//
+// 验证 X-Signature 头中的签名：Base64Decode(ak=xxx&sign=xxx&t=xxx)。
+// 规范签名格式见 signRequest 文档。中间件自身强制时间戳新鲜度窗口（默认 ±5 分钟，
+// 可用 WithTimestampWindow 配置），使用常量时间比较签名，验签失败时不向客户端回显
+// 服务端计算出的签名（避免调试模式成为凭据预言机）。
+func Auth(authFace AuthFace, opts ...Option) app.HandlerFunc {
+	o := &authOptions{timestampWindow: defaultTimestampWindow}
+	for _, opt := range opts {
+		opt(o)
+	}
+
 	return func(ctx context.Context, c *app.RequestContext) {
 		ak, sign, t, err := parseAuthorization(&c.Request)
 		if err != nil {
 			c.AbortWithStatus(consts.StatusBadRequest)
+			return
+		}
+
+		if !timestampFresh(t, o.timestampWindow, time.Now) {
+			c.AbortWithStatus(consts.StatusUnauthorized)
 			return
 		}
 
@@ -44,10 +78,11 @@ func Auth(authFace AuthFace) app.HandlerFunc {
 			return
 		}
 
-		expected := signRequest(ak, sk, string(c.Request.Path()), t)
-		if expected != sign {
+		expected := signRequest(ak, sk, string(c.Request.Method()),
+			string(c.Request.RequestURI()), t, c.Request.Body())
+		if !hmac.Equal([]byte(expected), []byte(sign)) {
 			if isDebug {
-				c.AbortWithMsg(fmt.Sprintf("sign invalid, client:%s server:%s", sign, expected), consts.StatusForbidden)
+				c.AbortWithMsg("sign invalid", consts.StatusForbidden)
 			} else {
 				c.AbortWithStatus(consts.StatusUnauthorized)
 			}
@@ -58,7 +93,21 @@ func Auth(authFace AuthFace) app.HandlerFunc {
 	}
 }
 
-// parseAuthorization 从 X-Signature 头解析 ak, sign, t
+// timestampFresh 判断 Unix 秒级时间戳 t 是否落在 ±window 新鲜度窗口内。
+// now 通过参数注入以便测试；window <= 0 时回退默认窗口。
+func timestampFresh(t int64, window time.Duration, now func() time.Time) bool {
+	if window <= 0 {
+		window = defaultTimestampWindow
+	}
+	diff := now().Unix() - t
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff <= int64(window/time.Second)
+}
+
+// parseAuthorization 从 X-Signature 头解析 ak, sign, t。
+// 时间戳解析失败时返回错误（拒绝请求），不再吞错导致 t=0。
 func parseAuthorization(request *protocol.Request) (ak, sign string, t int64, err error) {
 	auth := string(request.Header.Peek("X-Signature"))
 	if auth == "" {
@@ -92,20 +141,42 @@ func parseAuthorization(request *protocol.Request) (ak, sign string, t int64, er
 			Code(goerror.CodeParamInvalid).
 			Errorf("sign is empty")
 	}
-	if tt, ok := kvs["t"]; !ok || tt == "" {
+	tt, ok := kvs["t"]
+	if !ok || tt == "" {
 		return "", "", 0, goerror.In("auth.parseAuthorization").
 			Code(goerror.CodeParamInvalid).
 			Errorf("timestamp is empty")
-	} else {
-		t, _ = strconv.ParseInt(tt, 10, 64)
 	}
+	parsed, perr := strconv.ParseInt(tt, 10, 64)
+	if perr != nil {
+		return "", "", 0, goerror.In("auth.parseAuthorization").
+			Code(goerror.CodeParamInvalid).
+			Wrap(perr)
+	}
+	t = parsed
 
 	return ak, sign, t, nil
 }
 
-// signRequest 计算请求签名
-func signRequest(ak, sk, path string, t int64) string {
-	msg := fmt.Sprintf("%s%s/%d/%s", ak, path, t, ak)
+// signRequest 计算请求签名。
+//
+// 规范签名格式（client 与 server 必须一致）：
+//
+//	stringToSign = ak + "\n" + method + "\n" + requestURI + "\n" + timestamp + "\n" + sha256hex(body)
+//	signature    = hex( HMAC-SHA256( key = sk, msg = stringToSign ) )
+//
+// method 为大写 HTTP 方法；requestURI 为 origin-form 请求目标（path?query）；
+// timestamp 为十进制秒级时间戳；sha256hex(body) 为原始 body 的 SHA-256 小写十六进制
+// （无 body 时为空输入的 SHA-256）。
+func signRequest(ak, sk, method, requestURI string, t int64, body []byte) string {
+	bodyHash := sha256.Sum256(body)
+	msg := strings.Join([]string{
+		ak,
+		method,
+		requestURI,
+		strconv.FormatInt(t, 10),
+		hex.EncodeToString(bodyHash[:]),
+	}, "\n")
 	h := hmac.New(sha256.New, []byte(sk))
 	h.Write([]byte(msg))
 	return hex.EncodeToString(h.Sum(nil))

--- a/go-framework/hertz/middleware/auth_test.go
+++ b/go-framework/hertz/middleware/auth_test.go
@@ -1,45 +1,256 @@
 package middleware
 
 import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
 	"testing"
+	"time"
 
+	"github.com/cloudwego/hertz/pkg/app"
+	"github.com/cloudwego/hertz/pkg/common/config"
+	"github.com/cloudwego/hertz/pkg/common/ut"
+	"github.com/cloudwego/hertz/pkg/route"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSignRequest(t *testing.T) {
-	ak := "test-ak"
-	sk := "test-sk"
-	path := "/api/v1/test"
-	timestamp := int64(1700000000)
-
-	sign := signRequest(ak, sk, path, timestamp)
-	assert.NotEmpty(t, sign, "sign should not be empty")
-	// HMAC-SHA256 hex is 64 chars
-	assert.Len(t, sign, 64, "HMAC-SHA256 hex output should be 64 characters")
-}
+// ─────────────────────────────────────────────────────────────
+// signRequest 单元测试（#22 规范签名格式）
+// ─────────────────────────────────────────────────────────────
 
 func TestSignRequest_Deterministic(t *testing.T) {
-	s1 := signRequest("ak", "sk", "/path", 1234567890)
-	s2 := signRequest("ak", "sk", "/path", 1234567890)
-	assert.Equal(t, s1, s2, "same inputs should produce same signature")
+	body := []byte(`{"a":1}`)
+	s1 := signRequest("ak", "sk", "POST", "/p?x=1", 1700000000, body)
+	s2 := signRequest("ak", "sk", "POST", "/p?x=1", 1700000000, body)
+	assert.Equal(t, s1, s2)
+	assert.Len(t, s1, 64, "HMAC-SHA256 hex should be 64 chars")
 }
 
-func TestSignRequest_DifferentInputs(t *testing.T) {
-	s1 := signRequest("ak1", "sk", "/path", 1234567890)
-	s2 := signRequest("ak2", "sk", "/path", 1234567890)
-	assert.NotEqual(t, s1, s2, "different AK should produce different signature")
+func TestSignRequest_BindsMethodQueryBody(t *testing.T) {
+	base := signRequest("ak", "sk", "GET", "/t?amount=1", 1700000000, nil)
 
-	s3 := signRequest("ak1", "sk", "/other", 1234567890)
-	assert.NotEqual(t, s1, s3, "different path should produce different signature")
+	assert.NotEqual(t, base, signRequest("ak", "sk", "POST", "/t?amount=1", 1700000000, nil),
+		"different method must change signature")
+	assert.NotEqual(t, base, signRequest("ak", "sk", "GET", "/t?amount=9999", 1700000000, nil),
+		"different query must change signature")
+	assert.NotEqual(t, base, signRequest("ak", "sk", "GET", "/t?amount=1", 1700000000, []byte("x")),
+		"different body must change signature")
+	assert.NotEqual(t, base, signRequest("other", "sk", "GET", "/t?amount=1", 1700000000, nil))
+	assert.NotEqual(t, base, signRequest("ak", "sk2", "GET", "/t?amount=1", 1700000000, nil))
+	assert.NotEqual(t, base, signRequest("ak", "sk", "GET", "/t?amount=1", 1700000001, nil))
+}
 
-	s4 := signRequest("ak1", "sk", "/path", 9999999999)
-	assert.NotEqual(t, s1, s4, "different timestamp should produce different signature")
+func TestSignRequest_EmptyBodyUsesEmptySHA256(t *testing.T) {
+	empty := sha256.Sum256(nil)
+	assert.Len(t, hex.EncodeToString(empty[:]), 64)
+
+	s1 := signRequest("ak", "sk", "GET", "/p", 1, nil)
+	s2 := signRequest("ak", "sk", "GET", "/p", 1, []byte{})
+	assert.Equal(t, s1, s2, "nil body and empty body must hash identically")
+}
+
+func TestSignRequest_MessageFormat(t *testing.T) {
+	// 手工构造期望的规范化消息，固化签名格式契约。
+	ak, sk, method, uri := "ak", "sk", "GET", "/p"
+	var ts int64 = 1
+	body := []byte("hello")
+	bodyHash := sha256.Sum256(body)
+	msg := fmt.Sprintf("%s\n%s\n%s\n%d\n%s", ak, method, uri, ts, hex.EncodeToString(bodyHash[:]))
+
+	mac := hmac.New(sha256.New, []byte(sk))
+	mac.Write([]byte(msg))
+	want := hex.EncodeToString(mac.Sum(nil))
+	assert.Equal(t, want, signRequest(ak, sk, method, uri, ts, body))
 }
 
 func TestSignRequest_HexFormat(t *testing.T) {
-	sign := signRequest("ak", "sk", "/p", 12345)
+	sign := signRequest("ak", "sk", "GET", "/p", 12345, nil)
 	for _, ch := range sign {
 		assert.True(t, (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f'),
-			"sign should only contain hex characters, got '%c'", ch)
+			"sign must be lowercase hex, got '%c'", ch)
 	}
+}
+
+// ─────────────────────────────────────────────────────────────
+// timestampFresh 单元测试（#23 新鲜度窗口）
+// ─────────────────────────────────────────────────────────────
+
+func TestTimestampFresh(t *testing.T) {
+	now := func() time.Time { return time.Unix(1700000000, 0) }
+	win := 5 * time.Minute
+
+	assert.True(t, timestampFresh(1700000000, win, now), "exact now is fresh")
+	assert.True(t, timestampFresh(1700000000-299, win, now), "within past window")
+	assert.True(t, timestampFresh(1700000000+299, win, now), "within future window")
+	assert.True(t, timestampFresh(1700000000-300, win, now), "boundary is fresh")
+	assert.False(t, timestampFresh(1700000000-301, win, now), "expired past")
+	assert.False(t, timestampFresh(1700000000+301, win, now), "too far future")
+	assert.False(t, timestampFresh(0, win, now), "t=0 must be stale")
+}
+
+// ─────────────────────────────────────────────────────────────
+// 中间件级测试（hertz ut）
+// ─────────────────────────────────────────────────────────────
+
+// fakeAuthFace 测试用 AuthFace 实现。
+type fakeAuthFace struct {
+	sk      string
+	isDebug bool
+	err     error
+}
+
+func (f *fakeAuthFace) GetSk(_ context.Context, _ *app.RequestContext, _ string, _ int64) (string, bool, error) {
+	return f.sk, f.isDebug, f.err
+}
+
+// signHeader 构造 X-Signature 头：Base64(ak=..&sign=..&t=..)。
+func signHeader(ak, sk, method, requestURI string, t int64, body []byte) string {
+	sign := signRequest(ak, sk, method, requestURI, t, body)
+	raw := fmt.Sprintf("ak=%s&sign=%s&t=%d", ak, sign, t)
+	return base64.StdEncoding.EncodeToString([]byte(raw))
+}
+
+// newAuthTestEngine 构造带 Auth 中间件与 /test(GET/POST) 路由的测试引擎。
+func newAuthTestEngine(face AuthFace, opts ...Option) *route.Engine {
+	engine := route.NewEngine(config.NewOptions([]config.Option{}))
+	engine.Use(Auth(face, opts...))
+	engine.GET("/test", func(ctx context.Context, c *app.RequestContext) {
+		c.String(200, "ok")
+	})
+	engine.POST("/test", func(ctx context.Context, c *app.RequestContext) {
+		c.String(200, "ok")
+	})
+	return engine
+}
+
+// utBody 构造带正确 Len 的 ut.Body（hertz ut 需要 Len 才会把 body 写入请求）。
+func utBody(b []byte) *ut.Body {
+	return &ut.Body{Body: bytes.NewReader(b), Len: len(b)}
+}
+
+func TestAuth_ValidSignature_Passes(t *testing.T) {
+	now := time.Now().Unix()
+	engine := newAuthTestEngine(&fakeAuthFace{sk: "secret"})
+	hdr := signHeader("ak1", "secret", "GET", "/test", now, nil)
+	w := ut.PerformRequest(engine, "GET", "/test", nil,
+		ut.Header{Key: "X-Signature", Value: hdr})
+	assert.Equal(t, 200, w.Result().StatusCode())
+}
+
+// #21：调试模式验签失败不得回显服务端有效签名（凭据预言机）。
+func TestAuth_DebugDoesNotEchoServerSignature(t *testing.T) {
+	now := time.Now().Unix()
+	face := &fakeAuthFace{sk: "secret", isDebug: true}
+	engine := newAuthTestEngine(face)
+	badHdr := signHeader("ak1", "wrong-sk", "GET", "/test", now, nil)
+	w := ut.PerformRequest(engine, "GET", "/test", nil,
+		ut.Header{Key: "X-Signature", Value: badHdr})
+
+	res := w.Result()
+	assert.Equal(t, 403, res.StatusCode(), "debug mode rejects with 403")
+	body := string(res.Body())
+	expected := signRequest("ak1", "secret", "GET", "/test", now, nil)
+	assert.NotContains(t, body, expected, "server signature must not be echoed")
+	assert.NotContains(t, body, "server:", "legacy 'server:' leak must be gone")
+	assert.NotContains(t, body, "client:", "legacy 'client:' leak must be gone")
+}
+
+func TestAuth_WrongSignature_NonDebug_401(t *testing.T) {
+	now := time.Now().Unix()
+	engine := newAuthTestEngine(&fakeAuthFace{sk: "secret"})
+	badHdr := signHeader("ak1", "wrong-sk", "GET", "/test", now, nil)
+	w := ut.PerformRequest(engine, "GET", "/test", nil,
+		ut.Header{Key: "X-Signature", Value: badHdr})
+	assert.Equal(t, 401, w.Result().StatusCode())
+}
+
+// #22：query 篡改后原签名失效。
+func TestAuth_QueryTamper_Rejected(t *testing.T) {
+	now := time.Now().Unix()
+	engine := newAuthTestEngine(&fakeAuthFace{sk: "secret"})
+	// 客户端对 amount=1 签名
+	hdr := signHeader("ak1", "secret", "GET", "/test?amount=1", now, nil)
+	// 重放到 amount=9999
+	w := ut.PerformRequest(engine, "GET", "/test?amount=9999", nil,
+		ut.Header{Key: "X-Signature", Value: hdr})
+	assert.Equal(t, 401, w.Result().StatusCode(), "query tamper must be rejected")
+}
+
+// #22：method 篡改后原签名失效。
+func TestAuth_MethodTamper_Rejected(t *testing.T) {
+	now := time.Now().Unix()
+	engine := newAuthTestEngine(&fakeAuthFace{sk: "secret"})
+	hdr := signHeader("ak1", "secret", "GET", "/test", now, nil)
+	w := ut.PerformRequest(engine, "POST", "/test", nil,
+		ut.Header{Key: "X-Signature", Value: hdr})
+	assert.Equal(t, 401, w.Result().StatusCode(), "method tamper must be rejected")
+}
+
+// #22：body 篡改后原签名失效。
+func TestAuth_BodyTamper_Rejected(t *testing.T) {
+	now := time.Now().Unix()
+	engine := newAuthTestEngine(&fakeAuthFace{sk: "secret"})
+	hdr := signHeader("ak1", "secret", "POST", "/test", now, []byte(`{"a":1}`))
+	w := ut.PerformRequest(engine, "POST", "/test", utBody([]byte(`{"a":9999}`)),
+		ut.Header{Key: "X-Signature", Value: hdr})
+	assert.Equal(t, 401, w.Result().StatusCode(), "body tamper must be rejected")
+}
+
+// #22：带 query+body 的合法签名应通过。
+func TestAuth_ValidSignature_WithQueryAndBody_Passes(t *testing.T) {
+	now := time.Now().Unix()
+	engine := newAuthTestEngine(&fakeAuthFace{sk: "secret"})
+	hdr := signHeader("ak1", "secret", "POST", "/test?amount=1", now, []byte(`{"a":1}`))
+	w := ut.PerformRequest(engine, "POST", "/test?amount=1", utBody([]byte(`{"a":1}`)),
+		ut.Header{Key: "X-Signature", Value: hdr})
+	assert.Equal(t, 200, w.Result().StatusCode())
+}
+
+// #23：过期 / 未来时间戳被拒绝。
+func TestAuth_ExpiredTimestamp_Rejected(t *testing.T) {
+	stale := time.Now().Add(-10 * time.Minute).Unix()
+	engine := newAuthTestEngine(&fakeAuthFace{sk: "secret"})
+	hdr := signHeader("ak1", "secret", "GET", "/test", stale, nil)
+	w := ut.PerformRequest(engine, "GET", "/test", nil,
+		ut.Header{Key: "X-Signature", Value: hdr})
+	assert.Equal(t, 401, w.Result().StatusCode())
+}
+
+func TestAuth_FutureTimestamp_Rejected(t *testing.T) {
+	future := time.Now().Add(10 * time.Minute).Unix()
+	engine := newAuthTestEngine(&fakeAuthFace{sk: "secret"})
+	hdr := signHeader("ak1", "secret", "GET", "/test", future, nil)
+	w := ut.PerformRequest(engine, "GET", "/test", nil,
+		ut.Header{Key: "X-Signature", Value: hdr})
+	assert.Equal(t, 401, w.Result().StatusCode())
+}
+
+// #23：非法时间戳（解析失败）→ 400。
+func TestAuth_InvalidTimestamp_BadRequest(t *testing.T) {
+	raw := base64.StdEncoding.EncodeToString([]byte("ak=ak1&sign=deadbeef&t=abc"))
+	engine := newAuthTestEngine(&fakeAuthFace{sk: "secret"})
+	w := ut.PerformRequest(engine, "GET", "/test", nil,
+		ut.Header{Key: "X-Signature", Value: raw})
+	assert.Equal(t, 400, w.Result().StatusCode())
+}
+
+// #23：WithTimestampWindow 放大窗口后，10 分钟前的时间戳应被接受。
+func TestAuth_CustomTimestampWindow(t *testing.T) {
+	stale := time.Now().Add(-10 * time.Minute).Unix()
+	engine := newAuthTestEngine(&fakeAuthFace{sk: "secret"}, WithTimestampWindow(30*time.Minute))
+	hdr := signHeader("ak2", "secret", "GET", "/test", stale, nil)
+	w := ut.PerformRequest(engine, "GET", "/test", nil,
+		ut.Header{Key: "X-Signature", Value: hdr})
+	assert.Equal(t, 200, w.Result().StatusCode())
+}
+
+// 缺失 X-Signature 头 → 400。
+func TestAuth_MissingHeader_BadRequest(t *testing.T) {
+	engine := newAuthTestEngine(&fakeAuthFace{sk: "secret"})
+	w := ut.PerformRequest(engine, "GET", "/test", nil)
+	assert.Equal(t, 400, w.Result().StatusCode())
 }


### PR DESCRIPTION
## 概述

加固 AK/SK 鉴权中间件（`go-framework/hertz/middleware/auth.go`），修复多角色安全审计（跟踪 #34 · Phase 1 组 B）发现的三处缺陷。三处共享同一签名例程，故合并为一个 PR。

Closes #21
Closes #22
Closes #23

## 改动

### #21（priority:high）— 凭据预言机 / 认证绕过
- 调试模式验签失败**不再回显**服务端计算出的有效签名：`"sign invalid, client:%s server:%s"` → 通用 `"sign invalid"`。
- 签名比较由 `!=` 改为 **`hmac.Equal`**（常量时间）。

### #22 — 签名覆盖 method / query / body
规范签名消息重设计，绑定完整请求语义：

```
stringToSign = ak + "\n" + method + "\n" + requestURI + "\n" + timestamp + "\n" + sha256hex(body)
signature    = hex( HMAC-SHA256( key = sk, msg = stringToSign ) )
```

- `requestURI` = origin-form 请求目标（`path?query`）；body 始终参与哈希（空 body → 空输入的 SHA-256）。
- 旧方案仅签 `ak+path+"/"+t+"/"+ak`，捕获的 `GET ?amount=1` 签名可授权 `POST` 或篡改 query。

### #23 — 时间戳新鲜度窗口
- 中间件**自身**强制新鲜度窗口（默认 ±5min，`WithTimestampWindow` 可配），在 `GetSk` 之前拦截，不再依赖业务方。
- `strconv.ParseInt` 错误不再被吞掉：非法时间戳 → `400`（而非 `t=0`）。

## API 变更

- `Auth(authFace AuthFace, opts ...Option)` —— 新增向后兼容的 variadic options。
- 新增导出符号 `Option` / `WithTimestampWindow`（含 godoc）。
- ⚠️ **签名算法为有意破坏性变更**：旧方案不安全，仓库内无客户端/示例依赖旧算法；仓库外调用方需按上述规范格式更新。

## 测试

`auth_test.go` 18 个新增/更新用例：
- `signRequest` 格式绑定（method/query/body/ak/sk/t 变更 → 签名变化；空 body 等价；格式契约固化）
- `timestampFresh` 窗口边界
- 中间件级（hertz `ut`）：合法签名放行、调试模式不泄漏签名、method/query/body 篡改拒绝、过期/未来/非法时间戳拒绝、自定义窗口、缺头 400

## 验证

- `gofmt`：clean
- `go build ./go-common/... ./go-auth/... ./go-middleware/... ./go-framework/...`：OK
- `go vet ./go-framework/...`：OK
- `go test ./go-framework/... -count=1`：13 packages ok，0 FAIL
- `golangci-lint run --timeout=5m ./go-framework/...`（v2.12.2）：0 issues

## 范围说明

- 仅改 `auth.go` + `auth_test.go`。
- 未触及 `example/`（未注册 AKSK Auth 路由）、`go-common/auth/ak.go` 的 `RefreshSK`/MD5（属 #24 组 C）。

## 关联

- 跟踪 Issue：#34（Phase 1 组 B）
- 里程碑：安全加固
- 设计文档：`docs/superpowers/specs/2026-07-21-aksk-auth-hardening-design.md`
- 实施计划：`docs/superpowers/plans/2026-07-21-aksk-auth-hardening.md`
