### PR TITLE
fix(go-common): generate SK with crypto/rand instead of MD5(ak+timestamp)

### DIFF
--- a/docs/superpowers/plans/2026-07-21-crypto-rand-sk.md
+++ b/docs/superpowers/plans/2026-07-21-crypto-rand-sk.md
@@ -1,0 +1,427 @@
+# go-common/auth crypto/rand SK & AK Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the zero-entropy `MD5(ak+timestamp)` SK derivation with `crypto/rand`, and harden `GetRandAk` to use unbiased `crypto/rand` selection with a normalized charset.
+
+**Architecture:** Rewrite `go-common/auth/ak.go`: `RefreshSK()` becomes a no-arg function returning 32 `crypto/rand` bytes hex-encoded (64 chars), panicking on rand failure; `GetRandAk(length)` uses `crypto/rand.Int` rejection sampling over a normalized 62-char alphanumeric charset (fixing duplicate `O`, missing `0`, and the `Intn(61)` off-by-one that made `9` unreachable). Update the test file and the single example caller.
+
+**Tech Stack:** Go 1.26.5, stdlib only (`crypto/rand`, `encoding/hex`, `math/big`), stdlib `testing`, golangci-lint v2.
+
+## Global Constraints
+
+- **go-common has zero framework dependency** — only stdlib imports (`crypto/rand`, `encoding/hex`, `math/big`). Do NOT import Hertz/Kitex or any other go-tools module.
+- **All exported symbols need godoc** starting with the symbol name (revive `exported` rule).
+- **Error handling:** `crypto/rand` read failure → `panic` (keygen idiom, like `ed25519.GenerateKey`). Do not silently swallow; errcheck must be satisfied.
+- **gofmt-clean**; grouped imports stdlib-only for this file.
+- **Scope:** only `go-common/auth/ak.go`, `go-common/auth/ak_test.go`, and `example/handler/common_aksk.go`. No other files.
+- **Design source of truth:** `docs/superpowers/specs/2026-07-21-crypto-rand-sk-design.md` (decisions D1–D4).
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|------|----------------|--------|
+| `go-common/auth/ak.go` | AK + SK credential generation | Modify (rewrite both funcs, swap imports, add `akCharset` + `skBytes` consts) |
+| `go-common/auth/ak_test.go` | Unit tests for the above | Modify (new SK assertions, charset sanity + coverage, updated integration) |
+| `example/handler/common_aksk.go` | Demo route using the auth package | Modify (`RefreshSK(ak)` → `RefreshSK()`) |
+
+**Task ordering rationale:** Task 1 rewrites `GetRandAk` first (removes the `math/rand` import while `time` + `go-common/crypto` are still used by the unchanged `RefreshSK`), then Task 2 rewrites `RefreshSK` (drops the now-unused `time` + `crypto` imports, adds `encoding/hex`). This keeps the file compiling after every task.
+
+---
+
+### Task 1: GetRandAk — crypto/rand + normalized charset
+
+**Files:**
+- Modify: `go-common/auth/ak.go` (replace `GetRandAk` body, add `akCharset` const, swap `math/rand`→`crypto/rand`+`math/big`)
+- Test: `go-common/auth/ak_test.go`
+
+**Interfaces:**
+- Consumes: nothing new (stdlib only)
+- Produces: `func GetRandAk(length int) string` (unchanged signature), `const akCharset string` (62 chars: a-z, A-Z, 0-9)
+
+- [ ] **Step 1: Write the failing tests (behavioral, compile against the unchanged signature)**
+
+Replace the existing `TestGetRandAk_*` functions in `go-common/auth/ak_test.go` with:
+
+```go
+func TestGetRandAk_Length(t *testing.T) {
+	sizes := []int{0, 1, 5, 10, 32, 64}
+	for _, size := range sizes {
+		if ak := GetRandAk(size); len(ak) != size {
+			t.Errorf("GetRandAk(%d) length = %d, want %d", size, len(ak), size)
+		}
+	}
+	if ak := GetRandAk(-5); ak != "" {
+		t.Errorf("GetRandAk(-5) = %q, want empty string", ak)
+	}
+}
+
+func TestGetRandAk_OnlyAlphanumeric(t *testing.T) {
+	const validChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	for range 20 {
+		ak := GetRandAk(100)
+		for _, ch := range ak {
+			if !strings.ContainsRune(validChars, ch) {
+				t.Errorf("GetRandAk contains invalid char: %c", ch)
+			}
+		}
+	}
+}
+
+func TestGetRandAk_Uniqueness(t *testing.T) {
+	set := make(map[string]bool)
+	for range 100 {
+		ak := GetRandAk(16)
+		if set[ak] {
+			t.Errorf("duplicate AK generated (very unlikely): %s", ak)
+		}
+		set[ak] = true
+	}
+}
+
+func TestGetRandAk_Coverage(t *testing.T) {
+	ak := GetRandAk(10000)
+	if !strings.ContainsRune(ak, '0') {
+		t.Error("GetRandAk never produced '0' over 10000 chars; charset must include 0")
+	}
+	if !strings.ContainsRune(ak, '9') {
+		t.Error("GetRandAk never produced '9' over 10000 chars; Intn(61) off-by-one must be fixed")
+	}
+}
+```
+
+(Leave the existing `TestRefreshSK_*` and `TestIntegration_AKAndSK` untouched for now — they are rewritten in Task 2. Keep the `strings` import.)
+
+- [ ] **Step 2: Run the test to verify it fails (RED)**
+
+Run: `go test ./go-common/auth/ -run 'TestGetRandAk' -count=1`
+Expected: FAIL — `TestGetRandAk_Coverage` fails with both `'0'` and `'9'` missing (current charset omits `0` and `Intn(61)` excludes `9`).
+
+- [ ] **Step 3: Write the minimal implementation**
+
+In `go-common/auth/ak.go`, replace the `GetRandAk` function and the import block. Add the `akCharset` const. The file now reads:
+
+```go
+package auth
+
+import (
+	"crypto/rand"
+	"math/big"
+	"time"
+
+	"github.com/byx-darwin/go-tools/go-common/crypto"
+)
+
+// akCharset 是 AK 使用的 62 个字母数字字符（a-z、A-Z、0-9）。
+const akCharset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+// GetRandAk 生成并返回指定长度的随机 AK（Access Key）。
+//
+// 使用 crypto/rand 从 62 字符字母数字集合（a-z、A-Z、0-9）中无偏选取
+// （rand.Int 拒绝采样），修复了历史上 math/rand、字符表重复 'O'、缺失 '0'
+// 以及 Intn(61) 导致 '9' 永不出现的问题。length <= 0 时返回空字符串。
+// 若读取 crypto/rand 失败（在支持的平台上几乎不可能），将 panic。
+func GetRandAk(length int) string {
+	if length <= 0 {
+		return ""
+	}
+	ak := make([]byte, length)
+	max := big.NewInt(int64(len(akCharset)))
+	for i := range ak {
+		n, err := rand.Int(rand.Reader, max)
+		if err != nil {
+			panic("auth: read crypto/rand: " + err.Error())
+		}
+		ak[i] = akCharset[n.Int64()]
+	}
+	return string(ak)
+}
+
+// RefreshSK 刷新SK
+func RefreshSK(ak string) string {
+	signer := ak + "/" + time.Now().String()
+	return crypto.MD5([]byte(signer))
+}
+```
+
+Note: `math/rand` import is removed; `time` and `go-common/crypto` remain because the unchanged `RefreshSK` still uses them.
+
+- [ ] **Step 4: Run the tests to verify they pass (GREEN)**
+
+Run: `go test ./go-common/auth/ -run 'TestGetRandAk' -count=1`
+Expected: PASS (all four `TestGetRandAk_*`).
+
+- [ ] **Step 5: Add a white-box charset sanity test (now that `akCharset` exists)**
+
+Append to `go-common/auth/ak_test.go`:
+
+```go
+func TestAkCharset_Sanity(t *testing.T) {
+	seen := make(map[rune]bool)
+	for _, ch := range akCharset {
+		if seen[ch] {
+			t.Errorf("akCharset contains duplicate rune: %c", ch)
+		}
+		seen[ch] = true
+	}
+	if len(seen) != 62 {
+		t.Errorf("akCharset unique runes = %d, want 62", len(seen))
+	}
+	for _, must := range []rune{'0', '9', 'O', 'a', 'Z'} {
+		if !seen[must] {
+			t.Errorf("akCharset missing required rune: %c", must)
+		}
+	}
+}
+```
+
+Run: `go test ./go-common/auth/ -run 'TestAkCharset_Sanity' -count=1`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add go-common/auth/ak.go go-common/auth/ak_test.go
+git commit -m "fix(go-common): generate AK with crypto/rand and normalize charset
+
+Replace math/rand with crypto/rand (unbiased rejection sampling) and
+normalize the charset to 62 alphanumerics (a-z, A-Z, 0-9), fixing the
+duplicate 'O', missing '0', and Intn(61) off-by-one that made '9'
+unreachable.
+
+Refs #24"
+```
+
+---
+
+### Task 2: RefreshSK — crypto/rand, no-arg, hex 64, panic
+
+**Files:**
+- Modify: `go-common/auth/ak.go` (replace `RefreshSK`, add `skBytes` const, drop `time`+`crypto` imports, add `encoding/hex`)
+- Test: `go-common/auth/ak_test.go`
+
+**Interfaces:**
+- Consumes: `crypto/rand`, `encoding/hex` (stdlib)
+- Produces: `func RefreshSK() string` (**breaking**: drops the `ak` param), `const skBytes int` (=32)
+
+- [ ] **Step 1: Write the failing tests (new no-arg signature)**
+
+In `go-common/auth/ak_test.go`, delete the three old `RefreshSK` tests (`TestRefreshSK_ProducesValue`, `TestRefreshSK_SameInputProducesConsistentFormat`, `TestRefreshSK_DifferentAKProducesDifferentSK`) and replace with:
+
+```go
+func TestRefreshSK_Length(t *testing.T) {
+	if sk := RefreshSK(); len(sk) != 64 {
+		t.Errorf("RefreshSK length = %d, want 64 (32-byte hex)", len(sk))
+	}
+}
+
+func TestRefreshSK_HexCharset(t *testing.T) {
+	sk := RefreshSK()
+	for _, ch := range sk {
+		if (ch < '0' || ch > '9') && (ch < 'a' || ch > 'f') {
+			t.Errorf("RefreshSK contains non-hex char: %c", ch)
+		}
+	}
+}
+
+func TestRefreshSK_Uniqueness(t *testing.T) {
+	set := make(map[string]bool)
+	for range 100 {
+		sk := RefreshSK()
+		if set[sk] {
+			t.Errorf("duplicate SK generated (astronomically unlikely): %s", sk)
+		}
+		set[sk] = true
+	}
+}
+```
+
+And update the integration test to the no-arg call and 64-char SK:
+
+```go
+func TestIntegration_AKAndSK(t *testing.T) {
+	ak := GetRandAk(32)
+	if len(ak) != 32 {
+		t.Fatalf("AK length = %d, want 32", len(ak))
+	}
+	sk := RefreshSK()
+	if len(sk) != 64 {
+		t.Fatalf("SK length = %d, want 64 (32-byte hex)", len(sk))
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails (RED)**
+
+Run: `go test ./go-common/auth/ -run 'TestRefreshSK' -count=1`
+Expected: FAIL — build error: `too few arguments in call to RefreshSK` (old signature still takes `ak`). This compile failure is the RED state for a signature change.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+In `go-common/auth/ak.go`, replace the `RefreshSK` function and the import block. The file now reads (final form):
+
+```go
+package auth
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"math/big"
+)
+
+// akCharset 是 AK 使用的 62 个字母数字字符（a-z、A-Z、0-9）。
+const akCharset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+// skBytes 是 SK 的随机字节数（256 位熵）。
+const skBytes = 32
+
+// GetRandAk 生成并返回指定长度的随机 AK（Access Key）。
+//
+// 使用 crypto/rand 从 62 字符字母数字集合（a-z、A-Z、0-9）中无偏选取
+// （rand.Int 拒绝采样），修复了历史上 math/rand、字符表重复 'O'、缺失 '0'
+// 以及 Intn(61) 导致 '9' 永不出现的问题。length <= 0 时返回空字符串。
+// 若读取 crypto/rand 失败（在支持的平台上几乎不可能），将 panic。
+func GetRandAk(length int) string {
+	if length <= 0 {
+		return ""
+	}
+	ak := make([]byte, length)
+	max := big.NewInt(int64(len(akCharset)))
+	for i := range ak {
+		n, err := rand.Int(rand.Reader, max)
+		if err != nil {
+			panic("auth: read crypto/rand: " + err.Error())
+		}
+		ak[i] = akCharset[n.Int64()]
+	}
+	return string(ak)
+}
+
+// RefreshSK 生成并返回密码学安全的随机 SK（Secret Key）。
+//
+// 内部使用 crypto/rand 生成 32 字节（256 位）随机数据并 hex 编码（64 字符），
+// 用作 AK/SK 认证方案的 HMAC 密钥。SK 不再由 ak 或时间戳派生，具备完整秘密熵。
+// 若读取 crypto/rand 失败（在支持的平台上几乎不可能），将 panic。
+func RefreshSK() string {
+	b := make([]byte, skBytes)
+	if _, err := rand.Read(b); err != nil {
+		panic("auth: read crypto/rand: " + err.Error())
+	}
+	return hex.EncodeToString(b)
+}
+```
+
+Note: `time` and `github.com/byx-darwin/go-tools/go-common/crypto` imports are removed (no longer used); `encoding/hex` is added.
+
+- [ ] **Step 4: Run the tests to verify they pass (GREEN)**
+
+Run: `go test ./go-common/auth/ -count=1`
+Expected: PASS (all AK + SK + charset + integration tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go-common/auth/ak.go go-common/auth/ak_test.go
+git commit -m "fix(go-common): generate SK with crypto/rand instead of MD5(ak+timestamp)
+
+RefreshSK now returns 32 crypto/rand bytes hex-encoded (64 chars) and no
+longer derives the key from ak + wall-clock time (zero secret entropy).
+Breaking: drops the ak parameter (no external callers).
+
+Closes #24"
+```
+
+---
+
+### Task 3: Update the example caller
+
+**Files:**
+- Modify: `example/handler/common_aksk.go` (`RefreshSK(ak)` → `RefreshSK()`)
+
+**Interfaces:**
+- Consumes: `auth.RefreshSK() string` (no-arg, from Task 2), `auth.GetRandAk(32)`
+- Produces: a compiling `example` workspace module
+
+- [ ] **Step 1: Update the call site**
+
+In `example/handler/common_aksk.go`, change the SK generation line and its comment:
+
+```go
+	// 生成随机 AK。
+	ak := auth.GetRandAk(32)
+
+	// 生成密码学安全的随机 SK。
+	sk := auth.RefreshSK()
+```
+
+(The rest of the handler — `crypto.HMACSHA256([]byte(message), []byte(sk))` and the response map — is unchanged.)
+
+- [ ] **Step 2: Verify the example module compiles**
+
+Run: `go build ./example/...`
+Expected: success (no output).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add example/handler/common_aksk.go
+git commit -m "chore(example): use no-arg RefreshSK in aksk handler
+
+Refs #24"
+```
+
+---
+
+### Task 4: Full verification & static analysis
+
+**Files:** none (verification only; commit only if a fix is required)
+
+- [ ] **Step 1: gofmt check**
+
+Run: `gofmt -l go-common/auth/ak.go go-common/auth/ak_test.go example/handler/common_aksk.go`
+Expected: no output (all files formatted). If any file is listed, run `gofmt -w <file>`.
+
+- [ ] **Step 2: Module tests**
+
+Run: `go test ./go-common/... -count=1`
+Expected: PASS (all go-common packages).
+
+- [ ] **Step 3: go vet**
+
+Run: `go vet ./go-common/...`
+Expected: no output.
+
+- [ ] **Step 4: golangci-lint (per-module, v2)**
+
+Run: `golangci-lint run --timeout=5m ./go-common/...`
+Expected: no issues. (Verifies revive godoc on `RefreshSK`/`GetRandAk`/consts, errcheck on the handled `rand` errors, unparam — no unused params since `RefreshSK` is now no-arg.)
+
+- [ ] **Step 5: Standard workspace build**
+
+Run: `go build ./go-common/... ./go-auth/... ./go-middleware/... ./go-framework/...`
+Expected: success (no output).
+
+- [ ] **Step 6: Commit fixes (only if Steps 1–5 required any change)**
+
+```bash
+git add -A
+git commit -m "chore(go-common): gofmt/lint fixes for crypto/rand SK
+
+Refs #24"
+```
+
+If no changes were needed, skip this step.
+
+---
+
+## Acceptance Traceability (issue #24)
+
+| Acceptance Criterion | Covered by |
+|----------------------|-----------|
+| `RefreshSK` 改用 `crypto/rand`（32 字节，hex 编码） | Task 2 (impl + `TestRefreshSK_Length`/`_HexCharset`) |
+| 不再从标识符 + 时钟派生密钥 | Task 2 (no-arg `RefreshSK`, removes `ak`/`time`) |
+| 更新 godoc 注释说明 SK 生成方式 | Task 2 (`RefreshSK` godoc), Task 1 (`GetRandAk` godoc) |
+| 补充/更新单元测试验证 SK 长度与随机性 | Task 2 (`TestRefreshSK_*`), Task 1 (`TestGetRandAk_Coverage`/`TestAkCharset_Sanity`) |
+| `go test ./go-common/... -count=1` 通过 | Task 4 Step 2 |

--- a/docs/superpowers/specs/2026-07-21-crypto-rand-sk-design.md
+++ b/docs/superpowers/specs/2026-07-21-crypto-rand-sk-design.md
@@ -1,0 +1,155 @@
+# 设计文档：SK 改用 crypto/rand 生成（go-common/auth）
+
+- **Issue**: #24（generate SK with crypto/rand instead of MD5(ak+timestamp)）
+- **跟踪父 Issue**: #34（多角色审计修复路线图）— Phase 1 / 组 C（go-common 密钥与加密）
+- **里程碑**: 安全加固
+- **日期**: 2026-07-21
+- **模式**: full（gitflow-workflow `wf-2026-07-21-005`）
+
+## 1. 背景与问题
+
+`go-common/auth/ak.go` 的 `RefreshSK` 以 `SK = MD5(ak + "/" + time.Now().String())` 派生密钥：
+
+- **零秘密熵**：SK 是保护 AK/SK 认证方案的 HMAC 密钥，却完全由一个**公开标识符**（ak）和一个**墙上时钟时刻**决定。在创建时刻可知或可收窄（注册时间、计划轮换）时，无盐 MD5 可在 GPU 速度下暴力破解。SK 必须具备独立的、密码学强度的随机熵。
+- **同文件的相邻问题**：`GetRandAk` 使用 `math/rand`（非密码学安全），且字符表与取模存在多个历史 bug（见 §2）。
+
+### 现状调用面
+
+| 导出符号 | 签名 | 仓库内调用方 |
+|---------|------|-------------|
+| `RefreshSK` | `(ak string) string` | 仅 `example/handler/common_aksk.go` |
+| `GetRandAk` | `(length int) string` | 仅 `example/handler/common_aksk.go` |
+
+> **外部调用确认**：经确认，外部 / ncgo 生成的项目**未调用** `RefreshSK`，因此签名破坏性变更可接受。
+
+## 2. 目标
+
+1. `RefreshSK` 改用 `crypto/rand` 生成 SK，不再从标识符 + 时钟派生，确保密钥具备完整秘密熵。
+2. 一并修复 `GetRandAk`：改用 `crypto/rand` 无偏选取字符，并修复字符表历史 bug。
+3. 更新 godoc 注释说明新的生成方式。
+4. 补充/更新单元测试验证长度、字符集与随机性。
+5. 保持 `go-common` 零框架依赖（仅用标准库 `crypto/rand`、`encoding/hex`、`math/big`）。
+6. 通过 golangci-lint v2（revive godoc、errcheck、unparam）。
+
+### GetRandAk 现存 bug（本次一并修复）
+
+原字符表 `"...ABCDEFGHIJKLOM" + "NOPQRSTUVWXYZ123456789"`（拼接长 62）存在三个问题：
+
+| 问题 | 说明 |
+|------|------|
+| **`O` 重复** | 两个分块各含一个 `O`，抽到 `O` 的概率翻倍（有偏选取） |
+| **缺失 `0`** | digits 仅 `1-9`，字符表中完全没有数字零 |
+| **`9` 不可达** | `rand.Intn(61)` 仅取索引 0–60，排除最后一位 `9`（off-by-one） |
+
+> 因此「修 off-by-one」不是把 61 改成 62（那会保留 O 重复有偏 + 缺 0），而是**规范化字符表为标准 62 字母数字**（`a-z` + `A-Z` + `0-9`，含 `0`，`O` 仅一次），一次修掉三个问题。
+
+## 3. 关键决策
+
+| # | 决策点 | 结论 | 理由 |
+|---|--------|------|------|
+| D1 | API 形态 | **`RefreshSK() string`**（去掉 `ak` 参数） | SK 不再依赖 ak，保留 `ak` 参数会误导调用方以为存在派生关系；已确认无外部调用方，破坏性变更可接受 |
+| D2 | rand 失败处理 | **panic** | `crypto/rand.Read` 在支持的平台上实际不会失败；panic 是密钥生成惯用法（同 `ed25519.GenerateKey`）；保持 `string` 单返回值，避免破坏性 error 返回 |
+| D3 | 编码/长度 | **hex，64 字符**（32 字节随机数） | 与 `crypto` 包现有约定一致（MD5/SHA/HMAC 均返回 hex）；无 padding、URL 安全；256 位熵充足 |
+| D4 | 范围 | **一并修复 `GetRandAk`** | 同文件、同漏洞类别（凭据生成弱随机源）；`Intn(61)` 为真实正确性 bug；顺手规范化字符表 |
+
+## 4. API 设计
+
+修改文件 `go-common/auth/ak.go`：
+
+```go
+// akCharset 是 AK 使用的 62 个字母数字字符（a-z、A-Z、0-9）。
+const akCharset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+// skBytes 是 SK 的随机字节数（256 位熵）。
+const skBytes = 32
+
+// GetRandAk 生成并返回指定长度的随机 AK（Access Key）。
+//
+// 使用 crypto/rand 从 62 字符字母数字集合（a-z、A-Z、0-9）中无偏选取
+// （rand.Int 拒绝采样），修复了历史上 math/rand、字符表重复 'O'、缺失 '0'
+// 以及 Intn(61) 导致 '9' 永不出现的问题。
+// 若读取 crypto/rand 失败（在支持的平台上几乎不可能），将 panic。
+func GetRandAk(length int) string {
+    if length <= 0 {
+        return ""
+    }
+    ak := make([]byte, length)
+    max := big.NewInt(int64(len(akCharset)))
+    for i := range ak {
+        n, err := rand.Int(rand.Reader, max)
+        if err != nil {
+            panic("auth: read crypto/rand: " + err.Error())
+        }
+        ak[i] = akCharset[n.Int64()]
+    }
+    return string(ak)
+}
+
+// RefreshSK 生成并返回密码学安全的随机 SK（Secret Key）。
+//
+// 内部使用 crypto/rand 生成 32 字节（256 位）随机数据并 hex 编码（64 字符），
+// 用作 AK/SK 认证方案的 HMAC 密钥。SK 不再由 ak 或时间戳派生，具备完整秘密熵。
+// 若读取 crypto/rand 失败（在支持的平台上几乎不可能），将 panic。
+func RefreshSK() string {
+    b := make([]byte, skBytes)
+    if _, err := rand.Read(b); err != nil {
+        panic("auth: read crypto/rand: " + err.Error())
+    }
+    return hex.EncodeToString(b)
+}
+```
+
+### import 变更
+
+- **新增**：`crypto/rand`、`encoding/hex`、`math/big`
+- **移除**：`math/rand`、`time`、`github.com/byx-darwin/go-tools/go-common/crypto`（不再使用 `crypto.MD5`）
+
+## 5. 行为变更说明（破坏性）
+
+| 变更 | 前 | 后 |
+|------|----|----|
+| `RefreshSK` 签名 | `RefreshSK(ak string) string` | `RefreshSK() string` |
+| SK 来源 | `MD5(ak + "/" + time.Now())` | `crypto/rand` 32 字节 |
+| SK 长度 | 32 字符（MD5 hex） | 64 字符（hex） |
+| `GetRandAk` 随机源 | `math/rand`（有偏、`9` 不可达） | `crypto/rand`（无偏） |
+| `GetRandAk` 字符表 | 62 字符但 `O` 重复、缺 `0` | 标准 62 字母数字（含 `0`/`9`，`O` 一次） |
+| `GetRandAk(<=0)` | 返回 `""` | 返回 `""`（保持，显式 guard 避免 `make([]byte, -1)` panic） |
+
+> 迁移说明将写入 godoc。`RefreshSK` 为破坏性签名变更，但已确认无外部调用方，仓库内唯一调用方（example）同 PR 更新。
+
+## 6. 受影响文件
+
+| 文件 | 变更 |
+|------|------|
+| `go-common/auth/ak.go` | 重写 `RefreshSK`/`GetRandAk`，新增常量，更新 import 与 godoc |
+| `go-common/auth/ak_test.go` | 修订 SK 长度/字符集断言，改写依赖 ak 入参的用例，新增随机性/字符集健全性测试 |
+| `example/handler/common_aksk.go` | `auth.RefreshSK(ak)` → `auth.RefreshSK()` |
+
+## 7. 测试计划（stdlib `testing`）
+
+`ak_test.go`：
+
+1. **`TestRefreshSK_Length`**：`len(RefreshSK()) == 64`。
+2. **`TestRefreshSK_HexCharset`**：输出仅含 `[0-9a-f]`。
+3. **`TestRefreshSK_Uniqueness`**：多次调用（如 100 次）结果两两不同（256 位熵下碰撞概率可忽略）。替代原依赖 ak 入参的 `TestRefreshSK_DifferentAKProducesDifferentSK`。
+4. **`TestGetRandAk_Length`**：`{0, 1, 5, 10, 32, 64}` 长度正确；负数返回 `""`。
+5. **`TestGetRandAk_OnlyAlphanumeric`**：`validChars` 更新为规范字符表，输出字符均在其中。
+6. **`TestGetRandAk_Uniqueness`**：多次调用结果两两不同。
+7. **`TestAkCharset_Sanity`**（新增）：`akCharset` 恰为 62 个唯一字符（无重复、含 `0` 与 `9`）。
+8. **`TestGetRandAk_Coverage`**（新增，统计性）：生成足够长 AK（如 10000 字符），断言 `0` 与 `9` 均出现（修复前 `9` 永不可达）。
+9. **`TestIntegration_AKAndSK`**：端到端生成 AK(32) + SK，SK 长度断言由 32 改为 64。
+
+验证命令：`go test ./go-common/... -count=1`。
+
+## 8. 范围外（follow-up，建议另开 issue）
+
+- 无。`GetRandAk` 的弱随机源与 off-by-one 已纳入本次（D4）。AK 为公开标识符，其安全性随 `crypto/rand` 已充分。
+
+## 9. 风险与缓解
+
+| 风险 | 缓解 |
+|------|------|
+| 破坏性签名变更影响调用方 | 已确认无外部调用方；仓库内 example 同 PR 更新；godoc 明确说明 |
+| 字符表规范化改变 AK 输出分布 | 属修复历史 bug（O 重复有偏、缺 0、9 不可达），非随机性退化；测试覆盖 |
+| `crypto/rand` 读取失败导致 panic | 在支持的平台上实际不发生；panic 为密钥生成惯用法，消息可定位 |
+| example 未同步导致 workspace 编译失败 | 同 PR 内更新 example handler |

--- a/example/handler/common_aksk.go
+++ b/example/handler/common_aksk.go
@@ -19,8 +19,8 @@ func akskHandler(_ context.Context, c *app.RequestContext) {
 	// 生成随机 AK。
 	ak := auth.GetRandAk(32)
 
-	// 基于 AK 刷新 SK。
-	sk := auth.RefreshSK(ak)
+	// 生成密码学安全的随机 SK。
+	sk := auth.RefreshSK()
 
 	// 使用 HMAC-SHA256 签名（常见于 API 鉴权场景）。
 	message := "GET\n/api/users\n2026-06-26T00:00:00Z"

--- a/go-common/auth/ak.go
+++ b/go-common/auth/ak.go
@@ -2,14 +2,15 @@ package auth
 
 import (
 	"crypto/rand"
+	"encoding/hex"
 	"math/big"
-	"time"
-
-	"github.com/byx-darwin/go-tools/go-common/crypto"
 )
 
 // akCharset 是 AK 使用的 62 个字母数字字符（a-z、A-Z、0-9）。
 const akCharset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+// skBytes 是 SK 的随机字节数（256 位熵）。
+const skBytes = 32
 
 // GetRandAk 生成并返回指定长度的随机 AK（Access Key）。
 //
@@ -33,8 +34,15 @@ func GetRandAk(length int) string {
 	return string(ak)
 }
 
-// RefreshSK 刷新SK
-func RefreshSK(ak string) string {
-	signer := ak + "/" + time.Now().String()
-	return crypto.MD5([]byte(signer))
+// RefreshSK 生成并返回密码学安全的随机 SK（Secret Key）。
+//
+// 内部使用 crypto/rand 生成 32 字节（256 位）随机数据并 hex 编码（64 字符），
+// 用作 AK/SK 认证方案的 HMAC 密钥。SK 不再由 ak 或时间戳派生，具备完整秘密熵。
+// 若读取 crypto/rand 失败（在支持的平台上几乎不可能），将 panic。
+func RefreshSK() string {
+	b := make([]byte, skBytes)
+	if _, err := rand.Read(b); err != nil {
+		panic("auth: read crypto/rand: " + err.Error())
+	}
+	return hex.EncodeToString(b)
 }

--- a/go-common/auth/ak.go
+++ b/go-common/auth/ak.go
@@ -23,9 +23,9 @@ func GetRandAk(length int) string {
 		return ""
 	}
 	ak := make([]byte, length)
-	max := big.NewInt(int64(len(akCharset)))
+	maxVal := big.NewInt(int64(len(akCharset)))
 	for i := range ak {
-		n, err := rand.Int(rand.Reader, max)
+		n, err := rand.Int(rand.Reader, maxVal)
 		if err != nil {
 			panic("auth: read crypto/rand: " + err.Error())
 		}

--- a/go-common/auth/ak.go
+++ b/go-common/auth/ak.go
@@ -1,22 +1,36 @@
 package auth
 
 import (
-	"math/rand"
+	"crypto/rand"
+	"math/big"
 	"time"
 
 	"github.com/byx-darwin/go-tools/go-common/crypto"
 )
 
-// GetRandAk 生成随机ak
+// akCharset 是 AK 使用的 62 个字母数字字符（a-z、A-Z、0-9）。
+const akCharset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+// GetRandAk 生成并返回指定长度的随机 AK（Access Key）。
+//
+// 使用 crypto/rand 从 62 字符字母数字集合（a-z、A-Z、0-9）中无偏选取
+// （rand.Int 拒绝采样），修复了历史上 math/rand、字符表重复 'O'、缺失 '0'
+// 以及 Intn(61) 导致 '9' 永不出现的问题。length <= 0 时返回空字符串。
+// 若读取 crypto/rand 失败（在支持的平台上几乎不可能），将 panic。
 func GetRandAk(length int) string {
-	patter := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLOM" +
-		"NOPQRSTUVWXYZ123456789"
-	ak := ""
-	for index := 0; index < length; index++ {
-		n := rand.Intn(61)
-		ak += patter[n : n+1]
+	if length <= 0 {
+		return ""
 	}
-	return ak
+	ak := make([]byte, length)
+	max := big.NewInt(int64(len(akCharset)))
+	for i := range ak {
+		n, err := rand.Int(rand.Reader, max)
+		if err != nil {
+			panic("auth: read crypto/rand: " + err.Error())
+		}
+		ak[i] = akCharset[n.Int64()]
+	}
+	return string(ak)
 }
 
 // RefreshSK 刷新SK

--- a/go-common/auth/ak_test.go
+++ b/go-common/auth/ak_test.go
@@ -8,17 +8,17 @@ import (
 func TestGetRandAk_Length(t *testing.T) {
 	sizes := []int{0, 1, 5, 10, 32, 64}
 	for _, size := range sizes {
-		ak := GetRandAk(size)
-		if len(ak) != size {
+		if ak := GetRandAk(size); len(ak) != size {
 			t.Errorf("GetRandAk(%d) length = %d, want %d", size, len(ak), size)
 		}
+	}
+	if ak := GetRandAk(-5); ak != "" {
+		t.Errorf("GetRandAk(-5) = %q, want empty string", ak)
 	}
 }
 
 func TestGetRandAk_OnlyAlphanumeric(t *testing.T) {
-	const validChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLOMNOPQRSTUVWXYZ123456789"
-
-	// Generate multiple AKs to increase coverage
+	const validChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 	for range 20 {
 		ak := GetRandAk(100)
 		for _, ch := range ak {
@@ -30,7 +30,6 @@ func TestGetRandAk_OnlyAlphanumeric(t *testing.T) {
 }
 
 func TestGetRandAk_Uniqueness(t *testing.T) {
-	// Two calls with large length should almost certainly produce different results
 	set := make(map[string]bool)
 	for range 100 {
 		ak := GetRandAk(16)
@@ -38,6 +37,16 @@ func TestGetRandAk_Uniqueness(t *testing.T) {
 			t.Errorf("duplicate AK generated (very unlikely): %s", ak)
 		}
 		set[ak] = true
+	}
+}
+
+func TestGetRandAk_Coverage(t *testing.T) {
+	ak := GetRandAk(10000)
+	if !strings.ContainsRune(ak, '0') {
+		t.Error("GetRandAk never produced '0' over 10000 chars; charset must include 0")
+	}
+	if !strings.ContainsRune(ak, '9') {
+		t.Error("GetRandAk never produced '9' over 10000 chars; Intn(61) off-by-one must be fixed")
 	}
 }
 
@@ -91,5 +100,23 @@ func TestIntegration_AKAndSK(t *testing.T) {
 	sk := RefreshSK(ak)
 	if len(sk) != 32 {
 		t.Fatalf("SK length = %d, want 32 (MD5 hex)", len(sk))
+	}
+}
+
+func TestAkCharset_Sanity(t *testing.T) {
+	seen := make(map[rune]bool)
+	for _, ch := range akCharset {
+		if seen[ch] {
+			t.Errorf("akCharset contains duplicate rune: %c", ch)
+		}
+		seen[ch] = true
+	}
+	if len(seen) != 62 {
+		t.Errorf("akCharset unique runes = %d, want 62", len(seen))
+	}
+	for _, must := range []rune{'0', '9', 'O', 'a', 'Z'} {
+		if !seen[must] {
+			t.Errorf("akCharset missing required rune: %c", must)
+		}
 	}
 }

--- a/go-common/auth/ak_test.go
+++ b/go-common/auth/ak_test.go
@@ -50,26 +50,14 @@ func TestGetRandAk_Coverage(t *testing.T) {
 	}
 }
 
-func TestRefreshSK_ProducesValue(t *testing.T) {
-	ak := GetRandAk(10)
-	sk := RefreshSK(ak)
-	if sk == "" {
-		t.Error("RefreshSK should return non-empty string")
+func TestRefreshSK_Length(t *testing.T) {
+	if sk := RefreshSK(); len(sk) != 64 {
+		t.Errorf("RefreshSK length = %d, want 64 (32-byte hex)", len(sk))
 	}
 }
 
-func TestRefreshSK_SameInputProducesConsistentFormat(t *testing.T) {
-	// RefreshSK uses time.Now() internally so it changes per call,
-	// but the output should always be a hex-encoded MD5 (32 hex chars)
-	ak := GetRandAk(10)
-	sk := RefreshSK(ak)
-
-	// MD5 hex is always 32 chars
-	if len(sk) != 32 {
-		t.Errorf("RefreshSK hex length = %d, want 32 (MD5 hex)", len(sk))
-	}
-
-	// All chars should be hex
+func TestRefreshSK_HexCharset(t *testing.T) {
+	sk := RefreshSK()
 	for _, ch := range sk {
 		if (ch < '0' || ch > '9') && (ch < 'a' || ch > 'f') {
 			t.Errorf("RefreshSK contains non-hex char: %c", ch)
@@ -77,29 +65,25 @@ func TestRefreshSK_SameInputProducesConsistentFormat(t *testing.T) {
 	}
 }
 
-func TestRefreshSK_DifferentAKProducesDifferentSK(t *testing.T) {
-	ak1 := "testAK1"
-	ak2 := "testAK2"
-
-	// Same timestamp but different AK → different SK
-	// (Note: RefreshSK uses time.Now(), we just verify the signer is different)
-	sk1 := RefreshSK(ak1)
-	sk2 := RefreshSK(ak2)
-	if sk1 == sk2 {
-		t.Error("different AKs should produce different SKs")
+func TestRefreshSK_Uniqueness(t *testing.T) {
+	set := make(map[string]bool)
+	for range 100 {
+		sk := RefreshSK()
+		if set[sk] {
+			t.Errorf("duplicate SK generated (astronomically unlikely): %s", sk)
+		}
+		set[sk] = true
 	}
 }
 
 func TestIntegration_AKAndSK(t *testing.T) {
-	// End-to-end: generate AK, then SK
 	ak := GetRandAk(32)
 	if len(ak) != 32 {
 		t.Fatalf("AK length = %d, want 32", len(ak))
 	}
-
-	sk := RefreshSK(ak)
-	if len(sk) != 32 {
-		t.Fatalf("SK length = %d, want 32 (MD5 hex)", len(sk))
+	sk := RefreshSK()
+	if len(sk) != 64 {
+		t.Fatalf("SK length = %d, want 64 (32-byte hex)", len(sk))
 	}
 }
 


### PR DESCRIPTION
## Summary

修复 #24：`go-common/auth` 凭据生成改用 `crypto/rand`，消除零秘密熵的 SK 派生（原 `MD5(ak + "/" + time.Now())` 可由公开标识符 + 墙上时钟暴力破解）。

## Changes

- **`RefreshSK()`**：改为**无参**，用 `crypto/rand` 生成 32 字节（256 位）随机数并 hex 编码（64 字符）；`crypto/rand` 读取失败时 panic（密钥生成惯用法）。**不再由 ak / 时间戳派生**，具备完整秘密熵。（破坏性签名变更——已确认无外部调用方）
- **`GetRandAk(length)`**：改用 `crypto/rand.Int` 无偏选取（拒绝采样）；字符表规范化为 62 字母数字（`a-z`+`A-Z`+`0-9`），一次修复三个历史 bug：`O` 重复有偏、缺失 `0`、`Intn(61)` 导致 `9` 永不出现。
- **`example/handler/common_aksk.go`**：适配无参 `RefreshSK()`。

## Verification

- `go test ./go-common/... -count=1` ✅（13 包全过）
- `go vet` ✅ · `gofmt` ✅ · `golangci-lint v2 run ./go-common/...` ✅（0 issues）
- `go build` 四个库模块 + example ✅
- 全分支代码审查：**READY TO MERGE**（无 Critical/Important）

## Docs

- 设计：`docs/superpowers/specs/2026-07-21-crypto-rand-sk-design.md`
- 计划：`docs/superpowers/plans/2026-07-21-crypto-rand-sk.md`

Closes #24
