### PR TITLE
fix(error): align ProjectCodeMin to 40100 and add explicit AuthCode band bounds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,8 +47,8 @@ The 5-module → 3-library split (2026-06-23) is **complete**. ncgo generated pr
 ```
 go-framework: 10000-10499  (system, param, auth, config, RPC; defined in go-framework/error + obs 20601-20605)
 go-middleware: 20000-20699 (clickhouse 20401-20403, tls 20501-20504 defined in-package; redis/kafka/db/es bands reserved)
-go-auth:       40000-40099 (token, session, device auth errors; defined in go-auth/error)
-Project custom: 40100-59999 (business modules, external dependencies; no library predefinitions)
+go-auth:       40000-40099 (token, session, device auth errors; defined in go-auth/error; AuthCodeMin/Max)
+Project custom: 40100-59999 (business modules, external dependencies; no library predefinitions; ProjectCodeMin)
 ```
 
 See `specs/00_overview.md` for full error code table.

--- a/docs/superpowers/plans/2026-07-22-error-code-range-fix.md
+++ b/docs/superpowers/plans/2026-07-22-error-code-range-fix.md
@@ -1,0 +1,203 @@
+# 错误码段边界修正（#28）实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** 将 `go-common/error` 的 `ProjectCodeMin` 从 40000 修正为 40100，新增显式 `AuthCodeMin/Max=40000/40099`，并把「业务码 → HTTP 200」的边界从 `ProjectCodeMin` 解耦到 `AuthCodeMin`，使常量与文档一致且 auth 段（40000–40099）行为逐值不变。
+
+**Architecture:** 纯常量 + 边界解耦，不新增任何错误码、不改任何已分配码值（wire 稳定）。设计依据见 `docs/superpowers/specs/2026-07-22-error-code-range-fix-design.md`。
+
+**Tech Stack:** Go 1.25+（workspace go.work）、testify、golangci-lint v2。
+
+## Global Constraints
+
+- **码值不可变更**：仅改 `ProjectCodeMin` 常量值（40000→40100）与新增边界常量；任何已分配错误码值不变。
+- **行为逐值不变**：auth 段 40000–40099 的 `HTTPStatus`/`IsBusinessErrorCode`/`IsClientError`/`IsServerError` 结果与迁移前完全一致（靠边界切换到 `AuthCodeMin` 保证）。
+- **lint 逐模块运行**：`for m in go-common go-auth go-middleware go-framework; do golangci-lint run --timeout=5m ./$m/... || exit 1; done`（v2 ≥ v2.12.2）。
+- **revive**：新导出常量必须有 `// Name ...` godoc。
+- **提交前缀**：`fix(go-common)` / `docs`；每条 commit 尾部带 `(#28)`。
+- **TDD**：先写失败测试，再实现；每任务独立 commit。
+- **PR**：`Closes #28, Refs #34`；设计文档随分支提交。
+
+## File Structure
+
+| 文件 | 职责 | 动作 |
+|------|------|------|
+| `go-common/error/error.go` | 常量块 + `httpStatusForCode` + `IsBusinessErrorCode` + 包 godoc | 改（Task 2）|
+| `go-common/error/error_test.go` | 边界关系 + auth 边界值测试 | 改（Task 2）|
+| `CLAUDE.md` | Error Code Ranges 补注 `AuthCodeMin/Max` | 改（Task 3）|
+| `specs/00_overview.md` §四 | 补注边界常量说明 | 改（Task 3）|
+
+---
+
+### Task 1: 准备分支 + 提交设计文档与计划
+
+**Files:**
+- Commit（docs）: `docs/superpowers/specs/2026-07-22-error-code-range-fix-design.md`、`docs/superpowers/plans/2026-07-22-error-code-range-fix.md`
+
+- [ ] **Step 1: 创建 worktree 分支 `feat/28-error-code-range-fix`**
+
+由编排器创建。将主仓库工作区未跟踪的两个文档复制进 worktree 并提交：
+
+```bash
+mkdir -p docs/superpowers/specs docs/superpowers/plans
+cp <MAIN>/docs/superpowers/specs/2026-07-22-error-code-range-fix-design.md docs/superpowers/specs/
+cp <MAIN>/docs/superpowers/plans/2026-07-22-error-code-range-fix.md docs/superpowers/plans/
+git add docs/superpowers/specs/2026-07-22-error-code-range-fix-design.md docs/superpowers/plans/2026-07-22-error-code-range-fix.md
+git commit -m "docs: add error-code range fix design & implementation plan (#28)"
+```
+
+---
+
+### Task 2: go-common/error 常量 + 边界解耦（TDD）
+
+**Files:**
+- Modify: `go-common/error/error.go`
+- Modify: `go-common/error/error_test.go`
+
+- [ ] **Step 1: 写失败测试（`error_test.go`）**
+
+更新 `TestCodeConstants` 并新增 auth 边界测试：
+
+```go
+func TestCodeConstants(t *testing.T) {
+	assert.Less(t, FrameworkCodeMax, MiddlewareCodeMin)
+	assert.Less(t, MiddlewareCodeMax, AuthCodeMin)
+	assert.Less(t, AuthCodeMax, ProjectCodeMin)
+}
+
+// auth 段（40000-40099）是业务码段下限，行为须与迁移前逐值一致。
+func TestAuthBandBoundary(t *testing.T) {
+	assert.Equal(t, 40000, AuthCodeMin)
+	assert.Equal(t, 40099, AuthCodeMax)
+	assert.Equal(t, 40100, ProjectCodeMin)
+
+	// 业务码判定：auth 段 + project 段均为业务码
+	assert.True(t, IsBusinessErrorCode(AuthCodeMin))   // 40000
+	assert.True(t, IsBusinessErrorCode(AuthCodeMax))   // 40099
+	assert.True(t, IsBusinessErrorCode(ProjectCodeMin)) // 40100
+
+	// HTTP 兜底：auth 段未注册码 → 200
+	assert.Equal(t, 200, HTTPStatus(Code(40050).Public("auth_band").Wrap(errors.New("x"))))
+}
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `go test ./go-common/error/ -run 'TestCodeConstants|TestAuthBandBoundary' -count=1`
+Expected: FAIL — `undefined: AuthCodeMin`
+
+- [ ] **Step 3: 实现常量块（`error.go`）**
+
+将常量块替换为：
+
+```go
+// 错误码范围边界常量。
+const (
+	FrameworkCodeMin  = 10000 // go-framework 最小错误码
+	FrameworkCodeMax  = 10499 // go-framework 最大错误码
+	MiddlewareCodeMin = 20000 // go-middleware 最小错误码
+	MiddlewareCodeMax = 20699 // go-middleware 最大错误码
+	AuthCodeMin       = 40000 // go-auth 最小错误码（业务码段下限）
+	AuthCodeMax       = 40099 // go-auth 最大错误码
+	ProjectCodeMin    = 40100 // 项目自定义最小错误码
+	ProjectCodeMax    = 59999 // 项目自定义最大错误码
+)
+```
+
+- [ ] **Step 4: 边界解耦（`error.go`）**
+
+`httpStatusForCode` 兜底：
+
+```go
+	switch {
+	case code >= AuthCodeMin:   // 业务错误（auth 段 + project 段，RPC 成功，HTTP 200）
+		return 200
+	case code > 0:
+		return 500 // 未注册的框架/基础设施错误
+	default:
+		return 200 // 非 oops 错误 / 无错误码
+	}
+```
+
+`IsBusinessErrorCode`：
+
+```go
+func IsBusinessErrorCode(code int) bool {
+	return code >= AuthCodeMin || (code < FrameworkCodeMin && code > 0)
+}
+```
+
+- [ ] **Step 5: 同步包 godoc**
+
+将包注释第 9 行：
+
+```
+//     （业务码 ≥ ProjectCodeMin → 200；其余 >0 → 500；非 oops → 200）
+```
+
+改为：
+
+```
+//     （业务码 ≥ AuthCodeMin → 200；其余 >0 → 500；非 oops → 200）
+```
+
+- [ ] **Step 6: 运行全部 go-common/error 测试**
+
+Run: `go test ./go-common/error/ -count=1`
+Expected: PASS（新测试 + 现有 `TestHTTPStatus_Fallback`/`TestIsBusinessErrorCode`/`TestIsClientError`/`TestIsServerError` 全绿——auth 段行为逐值不变）
+
+- [ ] **Step 7: 提交**
+
+```bash
+gofmt -w go-common/error/error.go go-common/error/error_test.go
+git add go-common/error/error.go go-common/error/error_test.go
+git commit -m "fix(go-common): align ProjectCodeMin to 40100 and add AuthCode band bounds (#28)"
+```
+
+---
+
+### Task 3: 文档更新
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `specs/00_overview.md`
+
+- [ ] **Step 1: 改 `CLAUDE.md` Error Code Ranges**
+
+`go-auth` 行补注显式边界：
+
+```
+go-auth:       40000-40099 (token, session, device auth errors; defined in go-auth/error; AuthCodeMin/Max)
+Project custom: 40100-59999 (business modules, external dependencies; no library predefinitions; ProjectCodeMin)
+```
+
+- [ ] **Step 2: 改 `specs/00_overview.md` §四**
+
+在 go-auth 段与项目业务段说明处补注边界常量：
+
+```
+go-auth/error (autherror)  40001-40009  ── token/session/device/JWT → HTTP 200（AuthCodeMin=40000 / AuthCodeMax=40099）
+...
+项目业务       40100-59999  ── HTTP 200（ProjectCodeMin=40100；业务码段下限为 AuthCodeMin=40000）
+```
+
+并在「HTTP 状态映射机制」段把「业务码 → 200」的范围说明为「≥ AuthCodeMin（40000）」。
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add CLAUDE.md specs/00_overview.md
+git commit -m "docs: note AuthCodeMin/Max and ProjectCodeMin=40100 bounds (#28)"
+```
+
+---
+
+### Task 4: 最终全量验证
+
+- [ ] **Step 1: 全模块构建** — `go build ./go-common/... ./go-auth/... ./go-middleware/... ./go-framework/...`
+- [ ] **Step 2: go vet** — `go vet ./go-common/... ./go-auth/... ./go-middleware/... ./go-framework/...`
+- [ ] **Step 3: gofmt 检查** — `gofmt -l $(find . -name '*.go' -not -path '*/vendor/*' -not -path './.git/*')`（应无输出）
+- [ ] **Step 4: golangci-lint 逐模块** — `for m in go-common go-auth go-middleware go-framework; do golangci-lint run --timeout=5m ./$m/... || exit 1; done`
+- [ ] **Step 5: 全量测试** — `go test ./go-common/... ./go-auth/... ./go-middleware/... ./go-framework/... -count=1`
+- [ ] **Step 6: 边界值终检** — `grep -rn "ProjectCodeMin\s*=\s*40000\|code >= ProjectCodeMin" --include='*.go' go-common/`（应无输出：`ProjectCodeMin` 不再等于 40000，且兜底/判定不再用 `ProjectCodeMin`）
+- [ ] **Step 7: 若失败** — 最小修复，独立 commit `fix: <修复> (#28)`，重跑失败项。

--- a/docs/superpowers/specs/2026-07-22-error-code-range-fix-design.md
+++ b/docs/superpowers/specs/2026-07-22-error-code-range-fix-design.md
@@ -1,0 +1,126 @@
+# 错误码段边界修正设计（Issue #28）
+
+> **工作流**: wf-2026-07-22-001（fast mode）· **跟踪**: #34（多角色审计 roadmap · Phase 2）
+> **日期**: 2026-07-22 · **前置**: #27（错误码归属迁移，PR #48 已合并）
+> **范围**: 仅 #28（PR: `Closes #28, Refs #34`）
+
+## 1. 背景
+
+#27 完成了错误码归属迁移，但按设计「搬常量不改值」，`go-common/error` 的 `ProjectCodeMin` 仍为
+**40000**，与文档约定（`CLAUDE.md`/`specs`：go-auth `40000-40099`、project `40100-59999`）不一致，
+且缺少显式的 auth 段边界常量。#28 负责把常量对齐到文档，并补上 `AuthCodeMin/Max`。
+
+**#27 已提前化解的部分**：原 #28 AC 中的「去重 token 码」已随 #27 删除 go-common 的
+`CodeTokenInvalid=40112` / `CodeTokenExpired=40111`（及全部业务码 40010–40314）而完成；
+token 错误域现专属 `go-auth/error`（`40001`/`40002`）。本设计不再涉及。
+
+## 2. 事实发现（决策依据）
+
+| # | 事实 | 证据 |
+|---|------|------|
+| 1 | `ProjectCodeMin = 40000`，文档约定 project 段为 `40100-59999` | `go-common/error/error.go:44` vs `CLAUDE.md` |
+| 2 | go-common 无 `AuthCodeMin/Max`；auth 段 `40000-40099` 无显式边界常量 | `go-common/error/error.go` 常量块 |
+| 3 | `httpStatusForCode` 兜底用 `case code >= ProjectCodeMin: return 200` | `error.go:113` |
+| 4 | `IsBusinessErrorCode` 用 `code >= ProjectCodeMin \|\| (code < FrameworkCodeMin && code > 0)` | `error.go:135` |
+| 5 | **现有测试已锁定 auth 段（40000–40099）按业务码处理**：`TestHTTPStatus_Fallback`（`Code(40001)`→200，走兜底）、`TestIsBusinessErrorCode`（`IsBusinessErrorCode(40001)==true`、`(40010)==true`）、`TestIsClientError`/`TestIsServerError`（40001 非 4xx/5xx） | `go-common/error/error_test.go` |
+| 6 | go-auth 的错误码均经 `init()` 注册到 HTTP 注册表（40001–40009 → 200），但**兜底路径**仍依赖 `ProjectCodeMin` 边界 | `go-auth/error/error.go` |
+
+## 3. 决策
+
+**将业务码段下限从 `ProjectCodeMin`(40000) 解耦为 `AuthCodeMin`(40000)，`ProjectCodeMin` 修正为 40100。**
+
+### 3.1 常量变更（`go-common/error/error.go`）
+
+```go
+const (
+	FrameworkCodeMin  = 10000
+	FrameworkCodeMax  = 10499
+	MiddlewareCodeMin = 20000
+	MiddlewareCodeMax = 20699
+	AuthCodeMin       = 40000 // go-auth 最小错误码（业务码段下限）
+	AuthCodeMax       = 40099 // go-auth 最大错误码
+	ProjectCodeMin    = 40100 // 项目自定义最小错误码（原 40000 → 40100）
+	ProjectCodeMax    = 59999
+)
+```
+
+### 3.2 边界解耦（关键，避免回归）
+
+`httpStatusForCode` 兜底与 `IsBusinessErrorCode` 的「业务码 → 200」边界，从 `ProjectCodeMin`
+切换到 **`AuthCodeMin`**（业务码段真实下限 40000）：
+
+```go
+// httpStatusForCode 兜底
+case code >= AuthCodeMin:   // 原 ProjectCodeMin
+	return 200
+
+// IsBusinessErrorCode
+return code >= AuthCodeMin || (code < FrameworkCodeMin && code > 0)
+```
+
+**理由**：auth 段（40000–40099）与 project 段（40100–59999）共同构成「业务码 → HTTP 200」区间。
+业务码段下限是 `AuthCodeMin`(40000)，不是 `ProjectCodeMin`(40100)。若仅改 `ProjectCodeMin` 而不解耦，
+40000–40099 会跌出业务码判定 → 事实 5 的测试全部失败（行为回归）。解耦后行为**逐值不变**。
+
+### 3.3 godoc 同步
+
+包注释 `（业务码 ≥ ProjectCodeMin → 200…）` 改为 `（业务码 ≥ AuthCodeMin → 200…）`。
+
+## 4. 行为兼容矩阵（迁移前后逐值一致）
+
+| 错误码 | 迁移前 | 迁移后 | 说明 |
+|--------|--------|--------|------|
+| 40001（auth，注册）| 200 | 200 | 走注册表，不变 |
+| 40001（auth，兜底）| 200 | 200 | `>= AuthCodeMin(40000)`，不变 |
+| 40050（auth 段未分配，兜底）| 200 | 200 | `>= AuthCodeMin`，不变 |
+| 40100（project，兜底）| 200 | 200 | `>= AuthCodeMin`，不变 |
+| 20999（middleware 未注册）| 500 | 500 | `>0` 且 `<AuthCodeMin`，不变 |
+| 10000（framework）| 500/注册值 | 同 | 不变 |
+| `IsBusinessErrorCode(40001)` | true | true | `>= AuthCodeMin` |
+| `IsBusinessErrorCode(40010)` | true | true | `>= AuthCodeMin` |
+
+## 5. 迁移清单
+
+| 文件 | 改动 |
+|------|------|
+| `go-common/error/error.go` | `ProjectCodeMin` 40000→40100；新增 `AuthCodeMin=40000`/`AuthCodeMax=40099`；`httpStatusForCode` 兜底 + `IsBusinessErrorCode` 边界改用 `AuthCodeMin`；包 godoc 同步 |
+| `go-common/error/error_test.go` | `TestCodeConstants` 增加 `MiddlewareCodeMax < AuthCodeMin`、`AuthCodeMax < ProjectCodeMin` 断言；新增 auth 边界值测试（`IsBusinessErrorCode(40000/40099/40100)`、`HTTPStatus` 兜底 40050→200）；现有行为测试保持绿 |
+| `CLAUDE.md` | Error Code Ranges 已为目标值（go-auth 40000-40099 / project 40100-59999），补注 `AuthCodeMin/Max` 显式边界 |
+| `specs/00_overview.md` §四 | 补注 `AuthCodeMin/Max=40000/40099`、`ProjectCodeMin=40100` 常量与业务码段下限说明 |
+
+## 6. 测试策略
+
+- **TDD**：先改 `TestCodeConstants` + 新增 auth 边界测试（RED：`AuthCodeMin` 未定义编译失败），再实现（GREEN）。
+- **回归锁定**：现有 `TestHTTPStatus_Fallback` / `TestIsBusinessErrorCode` / `TestIsClientError` /
+  `TestIsServerError` 全绿（auth 段行为不变）。
+- **最终验证**：四模块 `go build` + `go vet` + `golangci-lint` v2 逐模块 + `go test -count=1` 全量。
+
+## 7. 范围边界与非目标
+
+**本 PR 做**：`ProjectCodeMin` 40000→40100；新增 `AuthCodeMin/Max`；边界解耦（`httpStatusForCode`/`IsBusinessErrorCode`）；测试 + 文档。
+
+**明确不做：**
+
+| 事项 | 归属 |
+|------|------|
+| 去重 token 码（40111/40112）| 已由 #27 完成 |
+| 改任何已分配码值 | 禁止（wire 稳定）|
+| 新增 auth/project 具体错误码 | 禁止（本 PR 只动边界常量）|
+| go-auth 段码值调整 | 不变（40001–40009 维持）|
+
+## 8. 风险与缓解
+
+| 风险 | 缓解 |
+|------|------|
+| 边界解耦遗漏导致 auth 段回归 | 现有测试已锁定 40001/40010 行为；TDD 先红后绿；行为兼容矩阵 §4 逐值核对 |
+| ncgo/下游依赖 `ProjectCodeMin==40000` | 仓库无 tag/release，无外部消费者；`ProjectCodeMin` 改为 40100 与文档一致，反而消除歧义 |
+| `IsBusinessErrorCode` 语义变化 | 解耦后对 ≥40000 的码逐值不变；仅「常量名」变化，行为不变 |
+
+## 9. 验收对照（Issue #28 AC）
+
+- [x] 去重 token 码（由 #27 完成）
+- [ ] `ProjectCodeMin` → 40100
+- [ ] 新增 `AuthCodeMin/Max=40000/40099`
+- [ ] （新增）`httpStatusForCode`/`IsBusinessErrorCode` 边界切换到 `AuthCodeMin`，auth 段行为不变
+- [ ] 更新 specs/CLAUDE.md
+- [ ] 受影响模块测试通过

--- a/go-common/error/error.go
+++ b/go-common/error/error.go
@@ -3,10 +3,10 @@
 // 本包是纯机制包，不持有任何模块的具体错误码：
 //
 //   - 构造/提取机制：Code、In、Extract、ExtractWithFallback、AsOopsError
-//   - 码段边界常量：Framework/Middleware/Project 的 Min/Max
+//   - 码段边界常量：Framework/Middleware/Auth/Project 的 Min/Max
 //   - HTTP 状态注册表：RegisterHTTPStatuses 供各属主模块在 init() 注册
 //     细粒度映射；HTTPStatus 先查注册表，再走范围兜底
-//     （业务码 ≥ ProjectCodeMin → 200；其余 >0 → 500；非 oops → 200）
+//     （业务码 ≥ AuthCodeMin → 200；其余 >0 → 500；非 oops → 200）
 //
 // 具体错误码由各属主模块定义：
 //
@@ -41,7 +41,9 @@ const (
 	FrameworkCodeMax  = 10499 // go-framework 最大错误码
 	MiddlewareCodeMin = 20000 // go-middleware 最小错误码
 	MiddlewareCodeMax = 20699 // go-middleware 最大错误码
-	ProjectCodeMin    = 40000 // 项目自定义最小错误码
+	AuthCodeMin       = 40000 // go-auth 最小错误码（业务码段下限）
+	AuthCodeMax       = 40099 // go-auth 最大错误码
+	ProjectCodeMin    = 40100 // 项目自定义最小错误码
 	ProjectCodeMax    = 59999 // 项目自定义最大错误码
 )
 
@@ -110,8 +112,8 @@ func httpStatusForCode(code int) int {
 		return status
 	}
 	switch {
-	case code >= ProjectCodeMin:
-		return 200 // 业务错误（RPC 调用成功，HTTP 200）
+	case code >= AuthCodeMin:
+		return 200 // 业务错误（auth 段 + project 段，RPC 调用成功，HTTP 200）
 	case code > 0:
 		return 500 // 未注册的框架/基础设施错误
 	default:
@@ -131,6 +133,7 @@ func IsServerError(code int) bool {
 }
 
 // IsBusinessErrorCode 判断错误码是否属于业务错误（200，RPC 成功）。
+// 业务码段下限为 AuthCodeMin（40000），涵盖 auth 段（40000-40099）与 project 段（40100-59999）。
 func IsBusinessErrorCode(code int) bool {
-	return code >= ProjectCodeMin || (code < FrameworkCodeMin && code > 0)
+	return code >= AuthCodeMin || (code < FrameworkCodeMin && code > 0)
 }

--- a/go-common/error/error_test.go
+++ b/go-common/error/error_test.go
@@ -18,7 +18,23 @@ func init() {
 
 func TestCodeConstants(t *testing.T) {
 	assert.Less(t, FrameworkCodeMax, MiddlewareCodeMin)
-	assert.Less(t, MiddlewareCodeMax, ProjectCodeMin)
+	assert.Less(t, MiddlewareCodeMax, AuthCodeMin)
+	assert.Less(t, AuthCodeMax, ProjectCodeMin)
+}
+
+// auth 段（40000-40099）是业务码段下限，行为须与迁移前逐值一致。
+func TestAuthBandBoundary(t *testing.T) {
+	assert.Equal(t, 40000, AuthCodeMin)
+	assert.Equal(t, 40099, AuthCodeMax)
+	assert.Equal(t, 40100, ProjectCodeMin)
+
+	// 业务码判定：auth 段 + project 段均为业务码
+	assert.True(t, IsBusinessErrorCode(AuthCodeMin))    // 40000
+	assert.True(t, IsBusinessErrorCode(AuthCodeMax))    // 40099
+	assert.True(t, IsBusinessErrorCode(ProjectCodeMin)) // 40100
+
+	// HTTP 兜底：auth 段未注册码 → 200
+	assert.Equal(t, 200, HTTPStatus(Code(40050).Public("auth_band").Wrap(errors.New("x"))))
 }
 
 // ── Code / Extract ──

--- a/specs/00_overview.md
+++ b/specs/00_overview.md
@@ -98,21 +98,21 @@ go-framework/error (frameworkerror)  10000-10013  ── system/param/auth/confi
 go-framework/error (frameworkerror)  obs 段 20601-20605  ── observability（framework 适配层使用）
   20601-20605  Obs  → HTTP 503（export 失败 20602 → 500）
 
-go-auth/error (autherror)  40001-40009  ── token/session/device/JWT → HTTP 200
+go-auth/error (autherror)  40001-40009  ── token/session/device/JWT → HTTP 200（AuthCodeMin=40000 / AuthCodeMax=40099）
 
 go-middleware  20000-20699（码段边界，包内按需定义）
   clickhouse   20401-20403  → HTTP 503（query 失败 20402 → 500）
   tls          20501-20504  → HTTP 503（send 失败 20502 → 500）
   redis/kafka/db/es 预留分配（尚无定义；需要时在各包内定义并 init() 注册）
 
-项目业务       40100-59999  ── HTTP 200（RPC 调用成功；库内无预定义，以下为推荐分配）
+项目业务       40100-59999  ── HTTP 200（ProjectCodeMin=40100；业务码段下限为 AuthCodeMin=40000；库内无预定义，以下为推荐分配）
   40010-40012  数据（NotFound/Duplicate/Conflict）
   40110-40113  认证（LoginFailed/TokenExpired/TokenInvalid/PermissionDenied）
   40210-40212  限制（RateLimit/QuotaExceeded/IPBlocked）
   40310-40314  状态（AccountDisabled/OrderInvalid/BalanceInsufficient/VerificationFailed/OperationDenied）
 ```
 
-HTTP 状态映射机制：各属主模块在 `init()` 中调用 `goerror.RegisterHTTPStatuses` 注册细粒度映射；`goerror.HTTPStatus` 先查注册表，再走范围兜底（业务码 → 200，其余未注册 >0 → 500，非 oops → 200）。
+HTTP 状态映射机制：各属主模块在 `init()` 中调用 `goerror.RegisterHTTPStatuses` 注册细粒度映射；`goerror.HTTPStatus` 先查注册表，再走范围兜底（业务码 ≥ AuthCodeMin（40000）→ 200，其余未注册 >0 → 500，非 oops → 200）。
 
 详见 `go-common/error/`（机制）、`go-framework/error/`（框架码）、`go-auth/error/`（认证码）、`go-middleware/{clickhouse,tls}/errors.go`（中间件码）。
 


### PR DESCRIPTION
## Summary

将 `go-common/error` 的错误码段边界常量对齐到文档约定（`CLAUDE.md`/`specs` 早已写好的目标值），并补上显式的 auth 段边界，消除 `ProjectCodeMin=40000` 与 go-auth 段（40000–40099）的重叠歧义。

Closes #28, Refs #34

## Changes

- **常量**：`ProjectCodeMin` 40000 → **40100**；新增 `AuthCodeMin = 40000` / `AuthCodeMax = 40099`。
- **边界解耦（关键，避免回归）**：`httpStatusForCode` 兜底与 `IsBusinessErrorCode` 的「业务码 → HTTP 200」边界，从 `ProjectCodeMin` 切换到 **`AuthCodeMin`**（业务码段真实下限 40000）。
  - 原因：auth 段（40000–40099）与 project 段（40100–59999）共同构成业务码区间；若仅改 `ProjectCodeMin` 而不解耦，40000–40099 会跌出业务码判定 → 现有测试（`Code(40001)→200`、`IsBusinessErrorCode(40001)==true`）失败。解耦后行为**逐值不变**。
- **godoc**：包注释同步（码段边界含 Auth；业务码 ≥ AuthCodeMin → 200）。
- **测试**：`TestCodeConstants` 增加 `MiddlewareCodeMax < AuthCodeMin < ... < AuthCodeMax < ProjectCodeMin` 关系断言；新增 `TestAuthBandBoundary`（边界值 40000/40099/40100、`IsBusinessErrorCode` 三段、HTTP 兜底 40050→200）。
- **文档**：`CLAUDE.md` Error Code Ranges 补注 `AuthCodeMin/Max` / `ProjectCodeMin`；`specs/00_overview.md` §四 补注边界常量与业务码段下限说明。

## Wire Stability

不新增任何错误码、不改任何已分配码值；仅改 `ProjectCodeMin` 一个常量值 + 新增 2 个边界常量。auth 段（40000–40099）的 `HTTPStatus`/`IsBusinessErrorCode`/`IsClientError`/`IsServerError` 结果迁移前后逐值一致（设计文档 §4 兼容矩阵）。

注：原 #28 AC 中的「去重 token 码」已由 #27（PR #48）完成，本 PR 不涉及。

## Validation

- `go build` / `go vet` / `gofmt`：全部通过
- `golangci-lint` v2 逐模块：go-common / go-auth / go-middleware / go-framework 均 0 issues
- `go test ./go-common/... ./go-auth/... ./go-middleware/... ./go-framework/... -count=1`：38 包全绿
- 边界终检 grep：`ProjectCodeMin` 不再等于 40000，兜底/判定逻辑不再引用 `ProjectCodeMin`

## Scope Note

- 仅动边界常量，不新增 auth/project 具体错误码。
- go-auth 段码值（40001–40009）维持不变。
- `ProjectCodeMin` 改为 40100 与文档一致，消除与 go-auth 段的重叠歧义。
