### PR TITLE
chore(release): remove replace/v0.0.0, establish release tooling (#29)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,41 @@ jobs:
           name: coverage-${{ matrix.module }}
           path: ${{ matrix.module }}-coverage.out
           retention-days: 7
+
+  mod-hygiene:
+    name: go.mod hygiene
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: check no replace in published modules
+        run: |
+          FAILED=0
+          for mod in go-common go-auth go-middleware go-framework; do
+            if grep -q '^replace' "$mod/go.mod"; then
+              echo "::error file=${mod}/go.mod::contains replace directive — published modules must not use replace"
+              FAILED=1
+            fi
+          done
+          if [[ "$FAILED" -eq 1 ]]; then
+            echo "Published modules must not contain replace directives."
+            echo "Local development uses go.work workspace resolution."
+            echo "See RELEASE.md for the release process."
+            exit 1
+          fi
+          echo "✓ No replace directives in published modules"
+
+      - name: check no v0.0.0 sibling requires
+        run: |
+          FAILED=0
+          for mod in go-auth go-middleware go-framework; do
+            if grep -q 'byx-darwin/go-tools/go-.* v0\.0\.0' "$mod/go.mod"; then
+              echo "::error file=${mod}/go.mod::contains v0.0.0 sibling require — use real published versions"
+              FAILED=1
+            fi
+          done
+          if [[ "$FAILED" -eq 1 ]]; then
+            echo "Sibling module requires must reference real published versions."
+            exit 1
+          fi
+          echo "✓ No v0.0.0 sibling requires"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: scan
         working-directory: ${{ matrix.module }}
-        run: GOWORK=off govulncheck ./...
+        run: govulncheck ./...
 
   codeql:
     name: CodeQL

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,117 @@
+# Release Process
+
+go-tools 包含四个独立版本化的 Go 模块，遵循 [Semantic Versioning](https://semver.org/)。
+
+## Modules
+
+| Module | Import Path | Dependencies |
+|--------|------------|--------------|
+| go-common | `github.com/byx-darwin/go-tools/go-common` | (none — bottom of DAG) |
+| go-auth | `github.com/byx-darwin/go-tools/go-auth` | go-common |
+| go-middleware | `github.com/byx-darwin/go-tools/go-middleware` | go-common, go-auth |
+| go-framework | `github.com/byx-darwin/go-tools/go-framework` | go-common, go-auth |
+
+## Version Policy
+
+- **v0.x**: API 可能在不升 major 的情况下发生破坏性变更
+- **v1.0.0**: 承诺 API 稳定，破坏性变更需升 major
+- 各模块独立版本，不要求同步升级
+
+## Tag Convention
+
+```
+<module>/v<major>.<minor>.<patch>[-prerelease]
+```
+
+Examples: `go-common/v0.1.0`, `go-auth/v1.2.3`, `go-framework/v2.0.0-rc.1`
+
+## Local Development
+
+本地开发使用 Go workspace 模式（默认）。`go.work` 的 `use` 指令让所有模块在本地互相解析，无需 `replace` 指令。
+
+```bash
+# 正常开发（workspace 模式，默认）
+go build ./go-auth/...       # go-common 通过 go.work 解析
+
+# 单模块模式（需要已发布的兄弟版本）
+GOWORK=off go build ./go-auth/...  # 从 proxy 解析 go-common@v0.1.0
+```
+
+> ⚠️ 发布模块的 go.mod **禁止**包含 `replace` 指令。CI 会检查并阻断。
+
+## Release Process
+
+### Single Module Release
+
+```bash
+# 1. 确保依赖的兄弟模块已发布所需版本
+#    例：go-auth v0.2.0 依赖 go-common v0.2.0
+
+# 2. 更新 sibling require（如需要）
+cd go-auth
+go get github.com/byx-darwin/go-tools/go-common@v0.2.0
+go mod tidy
+cd ..
+git add go-auth/go.mod go-auth/go.sum
+git commit -m "chore(go-auth): bump go-common to v0.2.0"
+git push
+
+# 3. 打 tag 并推送
+./scripts/release.sh go-auth v0.2.0
+```
+
+### Coordinated Multi-Module Release
+
+当多个模块需要同时升级时，按依赖顺序发布：
+
+```bash
+# 1. go-common（无兄弟依赖）
+./scripts/release.sh go-common v0.2.0
+
+# 2. go-auth（依赖 go-common）
+cd go-auth && go get github.com/byx-darwin/go-tools/go-common@v0.2.0 && go mod tidy && cd ..
+git add go-auth/ && git commit -m "chore(go-auth): bump go-common to v0.2.0"
+./scripts/release.sh go-auth v0.2.0
+
+# 3. go-middleware + go-framework（依赖 go-common + go-auth，可并行）
+cd go-middleware && go get github.com/byx-darwin/go-tools/go-common@v0.2.0 github.com/byx-darwin/go-tools/go-auth@v0.2.0 && go mod tidy && cd ..
+git add go-middleware/ && git commit -m "chore(go-middleware): bump siblings to v0.2.0"
+./scripts/release.sh go-middleware v0.2.0
+
+cd go-framework && go get github.com/byx-darwin/go-tools/go-common@v0.2.0 github.com/byx-darwin/go-tools/go-auth@v0.2.0 && go mod tidy && cd ..
+git add go-framework/ && git commit -m "chore(go-framework): bump siblings to v0.2.0"
+./scripts/release.sh go-framework v0.2.0
+```
+
+### Release Script
+
+`scripts/release.sh` 自动执行：
+1. 验证参数格式（module 目录存在、version 格式正确、tag 不重复、工作区干净）
+2. `go build` + `go test` 确保模块健康
+3. 创建 annotated tag 并推送到 origin
+
+### CI/CD
+
+- **Tag push** 触发 `.github/workflows/release.yml`：build → test → 创建 GitHub Release
+- **PR/push to main** 触发 `.github/workflows/ci.yml`：包含 go.mod 卫生检查（无 replace、无 v0.0.0）
+
+## Consumer Usage
+
+外部项目（如 ncgo 生成的项目）直接 require 即可：
+
+```go
+// go.mod
+require (
+    github.com/byx-darwin/go-tools/go-common v0.1.0
+    github.com/byx-darwin/go-tools/go-auth v0.1.0
+    github.com/byx-darwin/go-tools/go-framework v0.1.0
+)
+```
+
+无需任何 `replace` 指令。
+
+## History
+
+| Version | Date | Notes |
+|---------|------|-------|
+| v0.1.0 | 2026-07-22 | 首次发布。三库拆分完成、安全审计修复完成。 |

--- a/docs/superpowers/plans/2026-07-22-release-versioning.md
+++ b/docs/superpowers/plans/2026-07-22-release-versioning.md
@@ -1,0 +1,632 @@
+# Release Versioning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove `replace` directives and `v0.0.0` pins from published module go.mod files so external consumers can resolve them, and establish release tooling/documentation.
+
+**Architecture:** Clean go.mod approach — published modules (go-common, go-auth, go-middleware, go-framework) contain no `replace` directives and reference real published versions. Local development relies on `go.work` workspace resolution. A release script automates tagging, CI prevents regression, and RELEASE.md documents the process.
+
+**Tech Stack:** Go 1.26 modules, go.work workspace, GitHub Actions CI, bash scripting
+
+## Global Constraints
+
+- Go 1.26.5 (workspace mode via `go.work`)
+- Tag convention: `<module>/v<major>.<minor>.<patch>` (e.g., `go-common/v0.1.0`)
+- Published modules: go-common, go-auth, go-middleware, go-framework
+- `example/` module is internal-only — keeps `replace` directives
+- First version: v0.1.0 for all four modules
+- golangci-lint v2 must pass per module
+- All exported symbols need godoc comments
+
+---
+
+### Task 1: Clean go.mod Files
+
+**Files:**
+- Modify: `go-auth/go.mod`
+- Modify: `go-middleware/go.mod`
+- Modify: `go-framework/go.mod`
+- Modify: `go-auth/go.sum` (regenerated)
+- Modify: `go-middleware/go.sum` (regenerated)
+- Modify: `go-framework/go.sum` (regenerated)
+
+**Interfaces:**
+- Consumes: Nothing (first task)
+- Produces: Clean go.mod files with `v0.1.0` sibling requires, no `replace` directives
+
+- [ ] **Step 1: Edit go-auth/go.mod — remove replace, update require**
+
+In `go-auth/go.mod`, change:
+```
+require (
+	github.com/byx-darwin/go-tools/go-common v0.0.0
+```
+to:
+```
+require (
+	github.com/byx-darwin/go-tools/go-common v0.1.0
+```
+
+And delete the line:
+```
+replace github.com/byx-darwin/go-tools/go-common => ../go-common
+```
+
+- [ ] **Step 2: Edit go-middleware/go.mod — remove replace block, update requires**
+
+In `go-middleware/go.mod`, change:
+```
+	github.com/byx-darwin/go-tools/go-auth v0.0.0
+	github.com/byx-darwin/go-tools/go-common v0.0.0
+```
+to:
+```
+	github.com/byx-darwin/go-tools/go-auth v0.1.0
+	github.com/byx-darwin/go-tools/go-common v0.1.0
+```
+
+And delete the replace block:
+```
+replace (
+	github.com/byx-darwin/go-tools/go-auth => ../go-auth
+	github.com/byx-darwin/go-tools/go-common => ../go-common
+)
+```
+
+- [ ] **Step 3: Edit go-framework/go.mod — remove replace block, update requires**
+
+In `go-framework/go.mod`, change:
+```
+	github.com/byx-darwin/go-tools/go-auth v0.0.0-00010101000000-000000000000
+	github.com/byx-darwin/go-tools/go-common v0.0.0
+```
+to:
+```
+	github.com/byx-darwin/go-tools/go-auth v0.1.0
+	github.com/byx-darwin/go-tools/go-common v0.1.0
+```
+
+And delete the replace block:
+```
+replace (
+	github.com/byx-darwin/go-tools/go-auth => ../go-auth
+	github.com/byx-darwin/go-tools/go-common => ../go-common
+)
+```
+
+- [ ] **Step 4: Run go mod tidy in each affected module**
+
+Run:
+```bash
+cd go-auth && go mod tidy && cd ..
+cd go-middleware && go mod tidy && cd ..
+cd go-framework && go mod tidy && cd ..
+```
+Expected: go.sum files updated, no errors (workspace resolves siblings locally via go.work `use`)
+
+- [ ] **Step 5: Verify workspace builds**
+
+Run:
+```bash
+go build ./go-common/... ./go-auth/... ./go-middleware/... ./go-framework/...
+```
+Expected: BUILD SUCCESS (no output)
+
+- [ ] **Step 6: Verify go vet passes**
+
+Run:
+```bash
+go vet ./go-common/... ./go-auth/... ./go-middleware/... ./go-framework/...
+```
+Expected: No output (success)
+
+- [ ] **Step 7: Verify tests pass**
+
+Run:
+```bash
+go test ./go-common/... ./go-auth/... ./go-middleware/... ./go-framework/... -count=1
+```
+Expected: All tests pass
+
+- [ ] **Step 8: Verify no replace remains in published modules**
+
+Run:
+```bash
+grep -l '^replace' go-common/go.mod go-auth/go.mod go-middleware/go.mod go-framework/go.mod 2>/dev/null || echo "CLEAN: no replace directives"
+```
+Expected: `CLEAN: no replace directives`
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add go-auth/go.mod go-auth/go.sum go-middleware/go.mod go-middleware/go.sum go-framework/go.mod go-framework/go.sum
+git commit -m "chore(release): remove replace directives, pin siblings to v0.1.0 (#29)
+
+Remove replace directives from go-auth, go-middleware, go-framework.
+Set sibling module requires to v0.1.0 for independent publishability.
+Local dev continues via go.work workspace resolution.
+
+Closes #29"
+```
+
+---
+
+### Task 2: Create Release Script
+
+**Files:**
+- Create: `scripts/release.sh`
+
+**Interfaces:**
+- Consumes: Nothing (standalone utility)
+- Produces: `scripts/release.sh` — automates tag creation for future releases
+
+- [ ] **Step 1: Create scripts/release.sh**
+
+```bash
+#!/usr/bin/env bash
+# release.sh — Create and push a module release tag.
+#
+# Usage:
+#   ./scripts/release.sh <module> <version>
+#
+# Examples:
+#   ./scripts/release.sh go-common v0.2.0
+#   ./scripts/release.sh go-framework v1.0.0
+#
+# Pre-conditions:
+#   - Module directory exists
+#   - Working tree is clean
+#   - Tag does not already exist
+#   - Module builds and tests pass
+set -euo pipefail
+
+MODULE="${1:-}"
+VERSION="${2:-}"
+
+if [[ -z "$MODULE" || -z "$VERSION" ]]; then
+    echo "usage: $0 <module> <version>"
+    echo "example: $0 go-common v0.2.0"
+    exit 1
+fi
+
+# Validate version format
+if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+    echo "error: version must match v<major>.<minor>.<patch>[-prerelease]"
+    echo "  got: $VERSION"
+    exit 1
+fi
+
+# Validate module directory
+if [[ ! -d "$MODULE" ]]; then
+    echo "error: module directory '$MODULE' not found"
+    exit 1
+fi
+
+# Validate module has go.mod
+if [[ ! -f "$MODULE/go.mod" ]]; then
+    echo "error: $MODULE/go.mod not found"
+    exit 1
+fi
+
+TAG="${MODULE}/${VERSION}"
+
+# Check tag doesn't already exist
+if git tag -l "$TAG" | grep -q .; then
+    echo "error: tag '$TAG' already exists"
+    exit 1
+fi
+
+# Check working tree is clean
+if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo "error: working tree has uncommitted changes"
+    exit 1
+fi
+
+echo "→ Building $MODULE..."
+go build "./${MODULE}/..."
+
+echo "→ Testing $MODULE..."
+go test "./${MODULE}/..." -count=1
+
+echo "→ Creating tag $TAG..."
+git tag -a "$TAG" -m "${MODULE} ${VERSION}"
+
+echo "→ Pushing tag..."
+git push origin "$TAG"
+
+echo "✓ Released ${TAG}"
+```
+
+- [ ] **Step 2: Make script executable**
+
+Run:
+```bash
+chmod +x scripts/release.sh
+```
+
+- [ ] **Step 3: Verify script rejects bad input**
+
+Run:
+```bash
+./scripts/release.sh 2>&1 | grep -q "usage:" && echo "PASS: no args"
+./scripts/release.sh go-common bad-version 2>&1 | grep -q "error: version" && echo "PASS: bad version"
+./scripts/release.sh nonexistent v0.1.0 2>&1 | grep -q "error: module directory" && echo "PASS: bad module"
+```
+Expected: All three print PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/release.sh
+git commit -m "chore(release): add release.sh tag automation script (#29)"
+```
+
+---
+
+### Task 3: CI Hygiene Check
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+**Interfaces:**
+- Consumes: Clean go.mod invariant from Task 1
+- Produces: CI job that fails if `replace` is re-introduced in published modules
+
+- [ ] **Step 1: Add replace-directive check step to ci.yml**
+
+Add a new job after the existing `build-test-lint` job in `.github/workflows/ci.yml`:
+
+```yaml
+  mod-hygiene:
+    name: go.mod hygiene
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: check no replace in published modules
+        run: |
+          FAILED=0
+          for mod in go-common go-auth go-middleware go-framework; do
+            if grep -q '^replace' "$mod/go.mod"; then
+              echo "::error file=${mod}/go.mod::contains replace directive — published modules must not use replace"
+              FAILED=1
+            fi
+          done
+          if [[ "$FAILED" -eq 1 ]]; then
+            echo "Published modules must not contain replace directives."
+            echo "Local development uses go.work workspace resolution."
+            echo "See RELEASE.md for the release process."
+            exit 1
+          fi
+          echo "✓ No replace directives in published modules"
+
+      - name: check no v0.0.0 sibling requires
+        run: |
+          FAILED=0
+          for mod in go-auth go-middleware go-framework; do
+            if grep -q 'byx-darwin/go-tools/go-.* v0\.0\.0' "$mod/go.mod"; then
+              echo "::error file=${mod}/go.mod::contains v0.0.0 sibling require — use real published versions"
+              FAILED=1
+            fi
+          done
+          if [[ "$FAILED" -eq 1 ]]; then
+            echo "Sibling module requires must reference real published versions."
+            exit 1
+          fi
+          echo "✓ No v0.0.0 sibling requires"
+```
+
+- [ ] **Step 2: Verify CI yaml is valid**
+
+Run:
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))" && echo "YAML valid"
+```
+Expected: `YAML valid`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: add go.mod hygiene check (no replace, no v0.0.0) (#29)"
+```
+
+---
+
+### Task 4: RELEASE.md Documentation
+
+**Files:**
+- Create: `RELEASE.md`
+
+**Interfaces:**
+- Consumes: Decisions from design spec, release script from Task 2
+- Produces: Developer-facing release documentation
+
+- [ ] **Step 1: Create RELEASE.md**
+
+```markdown
+# Release Process
+
+go-tools 包含四个独立版本化的 Go 模块，遵循 [Semantic Versioning](https://semver.org/)。
+
+## Modules
+
+| Module | Import Path | Dependencies |
+|--------|------------|--------------|
+| go-common | `github.com/byx-darwin/go-tools/go-common` | (none — bottom of DAG) |
+| go-auth | `github.com/byx-darwin/go-tools/go-auth` | go-common |
+| go-middleware | `github.com/byx-darwin/go-tools/go-middleware` | go-common, go-auth |
+| go-framework | `github.com/byx-darwin/go-tools/go-framework` | go-common, go-auth |
+
+## Version Policy
+
+- **v0.x**: API 可能在不升 major 的情况下发生破坏性变更
+- **v1.0.0**: 承诺 API 稳定，破坏性变更需升 major
+- 各模块独立版本，不要求同步升级
+
+## Tag Convention
+
+```
+<module>/v<major>.<minor>.<patch>[-prerelease]
+```
+
+Examples: `go-common/v0.1.0`, `go-auth/v1.2.3`, `go-framework/v2.0.0-rc.1`
+
+## Local Development
+
+本地开发使用 Go workspace 模式（默认）。`go.work` 的 `use` 指令让所有模块在本地互相解析，无需 `replace` 指令。
+
+```bash
+# 正常开发（workspace 模式，默认）
+go build ./go-auth/...       # go-common 通过 go.work 解析
+
+# 单模块模式（需要已发布的兄弟版本）
+GOWORK=off go build ./go-auth/...  # 从 proxy 解析 go-common@v0.1.0
+```
+
+> ⚠️ 发布模块的 go.mod **禁止**包含 `replace` 指令。CI 会检查并阻断。
+
+## Release Process
+
+### Single Module Release
+
+```bash
+# 1. 确保依赖的兄弟模块已发布所需版本
+#    例：go-auth v0.2.0 依赖 go-common v0.2.0
+
+# 2. 更新 sibling require（如需要）
+cd go-auth
+go get github.com/byx-darwin/go-tools/go-common@v0.2.0
+go mod tidy
+cd ..
+git add go-auth/go.mod go-auth/go.sum
+git commit -m "chore(go-auth): bump go-common to v0.2.0"
+git push
+
+# 3. 打 tag 并推送
+./scripts/release.sh go-auth v0.2.0
+```
+
+### Coordinated Multi-Module Release
+
+当多个模块需要同时升级时，按依赖顺序发布：
+
+```bash
+# 1. go-common（无兄弟依赖）
+./scripts/release.sh go-common v0.2.0
+
+# 2. go-auth（依赖 go-common）
+cd go-auth && go get github.com/byx-darwin/go-tools/go-common@v0.2.0 && go mod tidy && cd ..
+git add go-auth/ && git commit -m "chore(go-auth): bump go-common to v0.2.0"
+./scripts/release.sh go-auth v0.2.0
+
+# 3. go-middleware + go-framework（依赖 go-common + go-auth，可并行）
+cd go-middleware && go get github.com/byx-darwin/go-tools/go-common@v0.2.0 github.com/byx-darwin/go-tools/go-auth@v0.2.0 && go mod tidy && cd ..
+git add go-middleware/ && git commit -m "chore(go-middleware): bump siblings to v0.2.0"
+./scripts/release.sh go-middleware v0.2.0
+
+cd go-framework && go get github.com/byx-darwin/go-tools/go-common@v0.2.0 github.com/byx-darwin/go-tools/go-auth@v0.2.0 && go mod tidy && cd ..
+git add go-framework/ && git commit -m "chore(go-framework): bump siblings to v0.2.0"
+./scripts/release.sh go-framework v0.2.0
+```
+
+### Release Script
+
+`scripts/release.sh` 自动执行：
+1. 验证参数格式（module 目录存在、version 格式正确、tag 不重复、工作区干净）
+2. `go build` + `go test` 确保模块健康
+3. 创建 annotated tag 并推送到 origin
+
+### CI/CD
+
+- **Tag push** 触发 `.github/workflows/release.yml`：build → test → 创建 GitHub Release
+- **PR/push to main** 触发 `.github/workflows/ci.yml`：包含 go.mod 卫生检查（无 replace、无 v0.0.0）
+
+## Consumer Usage
+
+外部项目（如 ncgo 生成的项目）直接 require 即可：
+
+```go
+// go.mod
+require (
+    github.com/byx-darwin/go-tools/go-common v0.1.0
+    github.com/byx-darwin/go-tools/go-auth v0.1.0
+    github.com/byx-darwin/go-tools/go-framework v0.1.0
+)
+```
+
+无需任何 `replace` 指令。
+
+## History
+
+| Version | Date | Notes |
+|---------|------|-------|
+| v0.1.0 | 2026-07-22 | 首次发布。三库拆分完成、安全审计修复完成。 |
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add RELEASE.md
+git commit -m "docs: add RELEASE.md with versioning and release process (#29)"
+```
+
+---
+
+### Task 5: External Consumer Verification Script
+
+**Files:**
+- Create: `scripts/verify-consumer.sh`
+
+**Interfaces:**
+- Consumes: Published module tags (post-release)
+- Produces: Verification that external consumers can resolve all modules
+
+- [ ] **Step 1: Create scripts/verify-consumer.sh**
+
+```bash
+#!/usr/bin/env bash
+# verify-consumer.sh — Verify modules are resolvable from outside the workspace.
+#
+# Usage:
+#   ./scripts/verify-consumer.sh [version]
+#
+# Default version: v0.1.0
+#
+# Creates a temporary module that imports all four libraries and verifies
+# `go mod tidy` + `go build` succeed without any replace directives.
+set -euo pipefail
+
+VERSION="${1:-v0.1.0}"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "→ Verifying external consumer resolution for version ${VERSION}..."
+echo "  Temp dir: $TMPDIR"
+
+cd "$TMPDIR"
+
+# Initialize a fresh module (outside any workspace)
+export GOWORK=off
+go mod init verify-consumer
+
+# Create main.go importing all four modules
+cat > main.go << 'GOEOF'
+package main
+
+import (
+	_ "github.com/byx-darwin/go-tools/go-common/cache"
+	_ "github.com/byx-darwin/go-tools/go-auth/jwt"
+	_ "github.com/byx-darwin/go-tools/go-middleware/redis"
+	_ "github.com/byx-darwin/go-tools/go-framework/config"
+)
+
+func main() {}
+GOEOF
+
+# Add requires
+go mod edit \
+    -require="github.com/byx-darwin/go-tools/go-common@${VERSION}" \
+    -require="github.com/byx-darwin/go-tools/go-auth@${VERSION}" \
+    -require="github.com/byx-darwin/go-tools/go-middleware@${VERSION}" \
+    -require="github.com/byx-darwin/go-tools/go-framework@${VERSION}"
+
+echo "→ Running go mod tidy..."
+go mod tidy
+
+echo "→ Running go build..."
+go build .
+
+echo "✓ External consumer verification PASSED"
+echo "  All four modules resolved from proxy without replace directives."
+```
+
+- [ ] **Step 2: Make script executable**
+
+Run:
+```bash
+chmod +x scripts/verify-consumer.sh
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/verify-consumer.sh
+git commit -m "chore(release): add external consumer verification script (#29)"
+```
+
+---
+
+### Task 6: Final Validation
+
+**Files:**
+- None (validation only)
+
+**Interfaces:**
+- Consumes: All previous tasks
+- Produces: Confidence that the workspace is release-ready
+
+- [ ] **Step 1: Full workspace build**
+
+Run:
+```bash
+go build ./go-common/... ./go-auth/... ./go-middleware/... ./go-framework/...
+```
+Expected: Success (no output)
+
+- [ ] **Step 2: Full workspace vet**
+
+Run:
+```bash
+go vet ./go-common/... ./go-auth/... ./go-middleware/... ./go-framework/...
+```
+Expected: Success (no output)
+
+- [ ] **Step 3: Full workspace tests**
+
+Run:
+```bash
+go test ./go-common/... ./go-auth/... ./go-middleware/... ./go-framework/... -count=1
+```
+Expected: All pass
+
+- [ ] **Step 4: Lint per module**
+
+Run:
+```bash
+for m in go-common go-auth go-middleware go-framework; do
+  echo "=== $m ===" && golangci-lint run --timeout=5m ./$m/...
+done
+```
+Expected: No issues
+
+- [ ] **Step 5: gofmt check**
+
+Run:
+```bash
+gofmt -l $(find . -name '*.go' -not -path '*/vendor/*' -not -path './.git/*')
+```
+Expected: No output (all files formatted)
+
+- [ ] **Step 6: Verify go.mod hygiene locally**
+
+Run:
+```bash
+for mod in go-common go-auth go-middleware go-framework; do
+  if grep -q '^replace' "$mod/go.mod"; then
+    echo "FAIL: $mod has replace"; exit 1
+  fi
+done
+echo "✓ All published modules clean"
+```
+Expected: `✓ All published modules clean`
+
+- [ ] **Step 7: Verify go mod tidy is stable**
+
+Run:
+```bash
+cd go-auth && go mod tidy -diff && cd ..
+cd go-middleware && go mod tidy -diff && cd ..
+cd go-framework && go mod tidy -diff && cd ..
+```
+Expected: No diff output (go.sum already correct)

--- a/docs/superpowers/specs/2026-07-22-release-versioning-design.md
+++ b/docs/superpowers/specs/2026-07-22-release-versioning-design.md
@@ -1,0 +1,264 @@
+# Release Versioning Design: Clean go.mod + go.work Overlay
+
+> Issue: #29 (last item of tracking issue #34)
+> Date: 2026-07-22
+> Status: Approved
+> Decision: Approach B — clean go.mod, go.work for local dev
+
+## 1. Problem
+
+`go-auth`, `go-middleware`, and `go-framework` carry `replace` directives and
+`v0.0.0` require versions for sibling modules. The Go toolchain **ignores
+`replace` directives in dependency go.mod files**, so external consumers (e.g.
+ncgo-generated projects) attempting to resolve `go-framework` will try to fetch
+`go-auth@v0.0.0` — which has no backing tag — and fail. This blocks D4
+(independent versioning & release).
+
+## 2. Decision Summary
+
+| Item | Decision |
+|------|----------|
+| Release approach | **B: Clean go.mod + go.work overlay** |
+| First version | **v0.1.0** for all four modules |
+| Tag strategy | **Sequential**: go-common → go-auth → go-middleware + go-framework |
+| Dev-time resolution | `go.work` `use` directives (already in place) |
+| `example/` module | Keep `replace` (internal-only, never published) |
+
+## 3. Target go.mod State
+
+After this change, published modules' go.mod files contain **no `replace`
+directives** and reference **real published versions** for siblings:
+
+### go-common/go.mod (unchanged)
+```
+module github.com/byx-darwin/go-tools/go-common
+// no sibling requires — bottom of DAG
+```
+
+### go-auth/go.mod
+```diff
+-require github.com/byx-darwin/go-tools/go-common v0.0.0
++require github.com/byx-darwin/go-tools/go-common v0.1.0
+
+-replace github.com/byx-darwin/go-tools/go-common => ../go-common
+```
+
+### go-middleware/go.mod
+```diff
+-require github.com/byx-darwin/go-tools/go-auth v0.0.0
+-require github.com/byx-darwin/go-tools/go-common v0.0.0
++require github.com/byx-darwin/go-tools/go-auth v0.1.0
++require github.com/byx-darwin/go-tools/go-common v0.1.0
+
+-replace (
+-    github.com/byx-darwin/go-tools/go-auth => ../go-auth
+-    github.com/byx-darwin/go-tools/go-common => ../go-common
+-)
+```
+
+### go-framework/go.mod
+```diff
+-require github.com/byx-darwin/go-tools/go-auth v0.0.0-00010101000000-000000000000
+-require github.com/byx-darwin/go-tools/go-common v0.0.0
++require github.com/byx-darwin/go-tools/go-auth v0.1.0
++require github.com/byx-darwin/go-tools/go-common v0.1.0
+
+-replace (
+-    github.com/byx-darwin/go-tools/go-auth => ../go-auth
+-    github.com/byx-darwin/go-tools/go-common => ../go-common
+-)
+```
+
+### example/go.mod (NOT published — keep replace for convenience)
+```
+// Keep replace directives. example/ is in go.work `use` and is never tagged.
+```
+
+## 4. Bootstrap Sequence (First Release)
+
+Because go-auth requires a resolvable go-common tag, the first release must be
+sequential:
+
+```
+Step 1: Remove replace from go-auth/go.mod, set go-common require to v0.1.0
+        (temporarily use go.work to build/test — workspace resolves locally)
+Step 2: git tag go-common/v0.1.0 && git push origin go-common/v0.1.0
+        → wait for proxy.golang.org to index (or GOPROXY=direct)
+Step 3: Remove replace from go-auth/go.mod (already done in step 1)
+        git tag go-auth/v0.1.0 && git push origin go-auth/v0.1.0
+Step 4: Remove replace from go-middleware + go-framework, set requires to v0.1.0
+        git tag go-middleware/v0.1.0 && git push
+        git tag go-framework/v0.1.0 && git push
+```
+
+**Key constraint:** All four tags point to the SAME commit (or sequential
+commits on main). The go.mod files at each tag must reference only
+already-tagged sibling versions.
+
+### Practical Implementation
+
+Since all tags should point to the same final commit (where all go.mod files
+are clean), the actual sequence is:
+
+1. Make ONE commit that cleans all go.mod files (removes replace, sets v0.1.0),
+   run `go mod tidy` in each affected module to update go.sum
+2. Push to main
+3. Tag sequentially from that commit:
+   ```bash
+   git tag go-common/v0.1.0 <commit>
+   git push origin go-common/v0.1.0
+   # wait for proxy or use GOPROXY=direct for verification
+   git tag go-auth/v0.1.0 <commit>
+   git push origin go-auth/v0.1.0
+   git tag go-middleware/v0.1.0 <commit>
+   git push origin go-middleware/v0.1.0
+   git tag go-framework/v0.1.0 <commit>
+   git push origin go-framework/v0.1.0
+   ```
+
+This works because at the tagged commit:
+- `go-common` has no sibling requires → immediately resolvable
+- `go-auth` requires `go-common@v0.1.0` → resolvable once go-common tag exists
+- `go-middleware`/`go-framework` require both → resolvable once both tags exist
+
+The proxy fetches modules lazily, so as long as tags exist before a consumer
+tries to resolve the full dependency graph, all is well.
+
+## 5. Release Script
+
+Create `scripts/release.sh` to automate future releases:
+
+```bash
+#!/usr/bin/env bash
+# Usage: ./scripts/release.sh <module> <version>
+# Example: ./scripts/release.sh go-common v0.2.0
+set -euo pipefail
+
+MODULE="$1"
+VERSION="$2"
+TAG="${MODULE}/${VERSION}"
+
+# Pre-flight checks
+[[ -d "$MODULE" ]] || { echo "error: module dir $MODULE not found"; exit 1; }
+git diff --quiet || { echo "error: working tree dirty"; exit 1; }
+git tag -l "$TAG" | grep -q . && { echo "error: tag $TAG already exists"; exit 1; }
+
+# Verify module builds and tests pass
+go build "./${MODULE}/..."
+go test "./${MODULE}/..." -count=1
+
+# Create and push tag
+git tag -a "$TAG" -m "${MODULE} ${VERSION}"
+git push origin "$TAG"
+echo "✓ Tagged and pushed ${TAG}"
+```
+
+For **subsequent releases** that bump sibling versions:
+```bash
+# Example: releasing go-auth v0.2.0 which depends on go-common v0.2.0
+cd go-auth
+go get github.com/byx-darwin/go-tools/go-common@v0.2.0
+go mod tidy
+cd ..
+git add go-auth/go.mod go-auth/go.sum
+git commit -m "chore(go-auth): bump go-common to v0.2.0"
+./scripts/release.sh go-auth v0.2.0
+```
+
+## 6. CI Enhancement
+
+Add a **go.mod hygiene check** to `ci.yml` to prevent `replace` directives
+from being re-introduced in published modules:
+
+```yaml
+- name: check no replace in published modules
+  run: |
+    for mod in go-common go-auth go-middleware go-framework; do
+      if grep -q '^replace' "$mod/go.mod"; then
+        echo "::error::$mod/go.mod contains replace directive"
+        exit 1
+      fi
+    done
+```
+
+This runs on every PR and push to main, ensuring the clean go.mod invariant
+is maintained.
+
+## 7. Documentation
+
+Create `RELEASE.md` at repo root documenting:
+
+1. **Module structure** — 4 independently versioned modules, DAG topology
+2. **Version policy** — SemVer, v0.x allows breaking changes, v1.0.0 = stable API
+3. **Release process** — step-by-step for single-module and coordinated releases
+4. **Tag convention** — `<module>/v<major>.<minor>.<patch>`
+5. **Consumer usage** — how ncgo projects import these modules
+6. **Bootstrap history** — note that v0.1.0 was the initial coordinated release
+
+## 8. Verification
+
+After tagging, verify with an external consumer test:
+
+```bash
+# Create a temp module outside the workspace
+TMPDIR=$(mktemp -d)
+cd "$TMPDIR"
+go mod init verify-consumer
+cat > main.go << 'EOF'
+package main
+
+import (
+    _ "github.com/byx-darwin/go-tools/go-common/cache"
+    _ "github.com/byx-darwin/go-tools/go-auth/jwt"
+    _ "github.com/byx-darwin/go-tools/go-middleware/redis"
+    _ "github.com/byx-darwin/go-tools/go-framework/hertz/server"
+)
+
+func main() {}
+EOF
+go mod tidy  # must succeed without replace
+go build .   # must compile
+```
+
+Success criteria: `go mod tidy` resolves all modules from proxy without errors.
+
+## 9. Development Workflow (Post-Change)
+
+With `replace` removed, local development relies on `go.work`:
+
+```bash
+# Normal development (workspace mode — default)
+go build ./go-auth/...    # resolves go-common via go.work `use`
+
+# Single-module mode (GOWORK=off) — requires published sibling versions
+GOWORK=off go build ./go-auth/...  # resolves go-common@v0.1.0 from proxy
+```
+
+The `go.work` file already lists all modules in `use`, so no changes needed
+there. Developers must always build from the workspace root (or with go.work
+active), which is the existing workflow.
+
+## 10. Risk & Mitigation
+
+| Risk | Mitigation |
+|------|-----------|
+| Proxy index delay after first tag | Use `GOPROXY=direct` for verification; wait ~5min for proxy.golang.org |
+| Developer builds with GOWORK=off before tags exist | Document: workspace mode is required until v0.1.0 tags are pushed |
+| Accidental replace re-introduction | CI check (§6) blocks PRs that add replace to published modules |
+| example/ module breaks | example/ keeps replace; it's in go.work `use` so both paths work |
+
+## 11. Scope Boundaries
+
+**In scope:**
+- Remove `replace` from go-auth, go-middleware, go-framework go.mod
+- Update sibling `require` to v0.1.0
+- Create `scripts/release.sh`
+- Add CI hygiene check
+- Write `RELEASE.md`
+- Verification script/test
+
+**Out of scope:**
+- `example/` module cleanup (keeps replace)
+- Actual tag creation (done separately after PR merge)
+- ncgo template updates (separate issue)
+- go.sum changes (handled by `go mod tidy`)

--- a/go-auth/go.mod
+++ b/go-auth/go.mod
@@ -3,7 +3,7 @@ module github.com/byx-darwin/go-tools/go-auth
 go 1.26.5
 
 require (
-	github.com/byx-darwin/go-tools/go-common v0.0.0
+	github.com/byx-darwin/go-tools/go-common v0.1.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/samber/oops v1.22.0
 	github.com/stretchr/testify v1.11.1
@@ -20,5 +20,3 @@ require (
 	golang.org/x/text v0.38.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/byx-darwin/go-tools/go-common => ../go-common

--- a/go-framework/go.mod
+++ b/go-framework/go.mod
@@ -4,8 +4,8 @@ go 1.26.5
 
 require (
 	github.com/bytedance/gopkg v0.1.4
-	github.com/byx-darwin/go-tools/go-auth v0.0.0-00010101000000-000000000000
-	github.com/byx-darwin/go-tools/go-common v0.0.0
+	github.com/byx-darwin/go-tools/go-auth v0.1.0
+	github.com/byx-darwin/go-tools/go-common v0.1.0
 	github.com/cloudwego/hertz v0.10.5
 	github.com/cloudwego/kitex v0.16.2
 	github.com/golang-jwt/jwt/v5 v5.3.1
@@ -23,11 +23,6 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
 	gopkg.in/yaml.v3 v3.0.1
-)
-
-replace (
-	github.com/byx-darwin/go-tools/go-auth => ../go-auth
-	github.com/byx-darwin/go-tools/go-common => ../go-common
 )
 
 require (

--- a/go-middleware/go.mod
+++ b/go-middleware/go.mod
@@ -5,8 +5,8 @@ go 1.26.5
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.46.0
 	github.com/alicebob/miniredis/v2 v2.38.0
-	github.com/byx-darwin/go-tools/go-auth v0.0.0
-	github.com/byx-darwin/go-tools/go-common v0.0.0
+	github.com/byx-darwin/go-tools/go-auth v0.1.0
+	github.com/byx-darwin/go-tools/go-common v0.1.0
 	github.com/elastic/go-elasticsearch/v8 v8.19.6
 	github.com/redis/go-redis/extra/redisotel/v9 v9.21.0
 	github.com/redis/go-redis/v9 v9.21.0
@@ -15,11 +15,6 @@ require (
 	github.com/segmentio/kafka-go v0.4.51
 	github.com/stretchr/testify v1.11.1
 	github.com/volcengine/volc-sdk-golang v1.0.250
-)
-
-replace (
-	github.com/byx-darwin/go-tools/go-auth => ../go-auth
-	github.com/byx-darwin/go-tools/go-common => ../go-common
 )
 
 require (

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# release.sh — Create and push a module release tag.
+#
+# Usage:
+#   ./scripts/release.sh <module> <version>
+#
+# Examples:
+#   ./scripts/release.sh go-common v0.2.0
+#   ./scripts/release.sh go-framework v1.0.0
+#
+# Pre-conditions:
+#   - Module directory exists
+#   - Working tree is clean
+#   - Tag does not already exist
+#   - Module builds and tests pass
+set -euo pipefail
+
+MODULE="${1:-}"
+VERSION="${2:-}"
+
+if [[ -z "$MODULE" || -z "$VERSION" ]]; then
+    echo "usage: $0 <module> <version>"
+    echo "example: $0 go-common v0.2.0"
+    exit 1
+fi
+
+# Validate version format
+if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+    echo "error: version must match v<major>.<minor>.<patch>[-prerelease]"
+    echo "  got: $VERSION"
+    exit 1
+fi
+
+# Validate module directory
+if [[ ! -d "$MODULE" ]]; then
+    echo "error: module directory '$MODULE' not found"
+    exit 1
+fi
+
+# Validate module has go.mod
+if [[ ! -f "$MODULE/go.mod" ]]; then
+    echo "error: $MODULE/go.mod not found"
+    exit 1
+fi
+
+TAG="${MODULE}/${VERSION}"
+
+# Check tag doesn't already exist
+if git tag -l "$TAG" | grep -q .; then
+    echo "error: tag '$TAG' already exists"
+    exit 1
+fi
+
+# Check working tree is clean
+if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo "error: working tree has uncommitted changes"
+    exit 1
+fi
+
+echo "→ Building $MODULE..."
+go build "./${MODULE}/..."
+
+echo "→ Testing $MODULE..."
+go test "./${MODULE}/..." -count=1
+
+echo "→ Creating tag $TAG..."
+git tag -a "$TAG" -m "${MODULE} ${VERSION}"
+
+echo "→ Pushing tag..."
+git push origin "$TAG"
+
+echo "✓ Released ${TAG}"

--- a/scripts/verify-consumer.sh
+++ b/scripts/verify-consumer.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# verify-consumer.sh — Verify modules are resolvable from outside the workspace.
+#
+# Usage:
+#   ./scripts/verify-consumer.sh [version]
+#
+# Default version: v0.1.0
+#
+# Creates a temporary module that imports all four libraries and verifies
+# `go mod tidy` + `go build` succeed without any replace directives.
+set -euo pipefail
+
+VERSION="${1:-v0.1.0}"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "→ Verifying external consumer resolution for version ${VERSION}..."
+echo "  Temp dir: $TMPDIR"
+
+cd "$TMPDIR"
+
+# Initialize a fresh module (outside any workspace)
+export GOWORK=off
+go mod init verify-consumer
+
+# Create main.go importing all four modules
+cat > main.go << 'GOEOF'
+package main
+
+import (
+	_ "github.com/byx-darwin/go-tools/go-common/cache"
+	_ "github.com/byx-darwin/go-tools/go-auth/jwt"
+	_ "github.com/byx-darwin/go-tools/go-middleware/redis"
+	_ "github.com/byx-darwin/go-tools/go-framework/config"
+)
+
+func main() {}
+GOEOF
+
+# Add requires
+go mod edit \
+    -require="github.com/byx-darwin/go-tools/go-common@${VERSION}" \
+    -require="github.com/byx-darwin/go-tools/go-auth@${VERSION}" \
+    -require="github.com/byx-darwin/go-tools/go-middleware@${VERSION}" \
+    -require="github.com/byx-darwin/go-tools/go-framework@${VERSION}"
+
+echo "→ Running go mod tidy..."
+go mod tidy
+
+echo "→ Running go build..."
+go build .
+
+echo "✓ External consumer verification PASSED"
+echo "  All four modules resolved from proxy without replace directives."


### PR DESCRIPTION
## Summary

Implements the release versioning design (Approach B: clean go.mod + go.work overlay).

## Changes

### 1. go.mod cleanup
- Removed `replace` directives from `go-auth`, `go-middleware`, `go-framework`
- Updated sibling module requires from `v0.0.0` to `v0.1.0`
- Local development continues via `go.work` workspace resolution

### 2. Release tooling
- `scripts/release.sh` — automated tag creation (validates module, version format, clean tree; builds + tests before tagging)
- `scripts/verify-consumer.sh` — external consumer verification (creates temp module, resolves all 4 libs from proxy)

### 3. CI hygiene
- Added `mod-hygiene` job to `ci.yml`: blocks PRs that re-introduce `replace` or `v0.0.0` sibling requires in published modules

### 4. Documentation
- `RELEASE.md` — version policy, tag convention, release process (single + coordinated), consumer usage

## Design Decisions

| Item | Decision |
|------|----------|
| Release approach | B: Clean go.mod + go.work overlay |
| First version | v0.1.0 (all modules) |
| Tag strategy | Sequential: go-common → go-auth → go-middleware + go-framework |
| example/ | Keeps replace (internal-only, not published) |

## Post-Merge Bootstrap

After this PR merges, the first release requires sequential tagging:
```bash
git tag go-common/v0.1.0 <merge-commit> && git push origin go-common/v0.1.0
git tag go-auth/v0.1.0 <merge-commit> && git push origin go-auth/v0.1.0
git tag go-middleware/v0.1.0 <merge-commit> && git push origin go-middleware/v0.1.0
git tag go-framework/v0.1.0 <merge-commit> && git push origin go-framework/v0.1.0
```

Then run `go mod tidy` in each module to update go.sum with real proxy hashes.

## Verification

- [x] `go build` passes (workspace mode)
- [x] `go vet` passes
- [x] `go test` passes (all modules)
- [x] No `replace` in published modules
- [x] `release.sh` input validation works

Closes #29
Tracking: #34 (last remaining item)