### PR TITLE
refactor(go-framework): remove orphaned HTTPAuth.TeaKey config field

### DIFF
--- a/docs/superpowers/plans/2026-07-22-remove-httpauth-teakey.md
+++ b/docs/superpowers/plans/2026-07-22-remove-httpauth-teakey.md
@@ -1,0 +1,187 @@
+# Remove HTTPAuth.TeaKey Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Delete the orphaned `HTTPAuth.TeaKey` config field and all its references, eliminating a misleading dead field left over from the TEA→AES-GCM migration (#25).
+
+**Architecture:** Pure deletion across 4 files — remove the struct field, update tests, clean the sensitive-key mask list, and remove the example YAML entry. No new code is introduced. `yaml.Unmarshal` ignores unknown fields, so existing deployed configs with `tea_key:` remain backward-compatible.
+
+**Tech Stack:** Go 1.25+, gopkg.in/yaml.v3, testify
+
+## Global Constraints
+
+- Config structs are ncgo scaffold source-of-truth — this is a source-breaking change for any Go code referencing `HTTPAuth.TeaKey` (confirmed: none exists in this repo)
+- `yaml.Unmarshal` (non-strict) silently ignores unknown fields — no runtime breakage for existing YAML configs
+- All exported symbols require godoc comments (revive linter)
+- gofmt-clean, golangci-lint v2 passing
+- ncgo template update is out of scope (separate repo, follow-up issue)
+
+---
+
+### Task 1: Remove TeaKey from HTTPAuth struct and update tests
+
+**Files:**
+- Modify: `go-framework/config/hertz/config.go:31-36`
+- Modify: `go-framework/config/hertz/config_test.go:28-44`
+
+**Interfaces:**
+- Produces: `HTTPAuth` struct with only `Enable`, `AK`, `SK` fields
+
+- [ ] **Step 1: Update the test to remove TeaKey references**
+
+In `go-framework/config/hertz/config_test.go`, remove `TeaKey` from the struct literal and its assertion:
+
+```go
+func TestServerConfig_Full(t *testing.T) {
+	c := &ServerConfig{
+		HTTP: &HTTPOption{
+			Network:      "tcp",
+			Port:         "8080",
+			Mode:         0,
+			ExitWaitTime: 5 * time.Second,
+			IdleTimeout:  30 * time.Second,
+			IsTransport:  true,
+			IsCors:       true,
+			IsRecovery:   true,
+		},
+		Auth: &HTTPAuth{
+			Enable: true,
+			AK:     "test-ak",
+			SK:     "test-sk",
+		},
+	}
+
+	assert.Equal(t, "tcp", c.HTTP.Network)
+	assert.Equal(t, "8080", c.HTTP.Port)
+	assert.Equal(t, 5*time.Second, c.HTTP.ExitWaitTime)
+	assert.Equal(t, 30*time.Second, c.HTTP.IdleTimeout)
+	assert.True(t, c.HTTP.IsCors)
+	assert.True(t, c.HTTP.IsRecovery)
+	assert.True(t, c.Auth.Enable)
+	assert.Equal(t, "test-ak", c.Auth.AK)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails (field still exists but unused)**
+
+Run: `cd /Volumes/SSD/workspace/github.com/byx-darwin/go-tools && go test ./go-framework/config/hertz/... -run TestServerConfig_Full -count=1 -v`
+
+Expected: PASS (the struct still has TeaKey, but test no longer sets it — this confirms the test compiles without referencing TeaKey)
+
+- [ ] **Step 3: Remove TeaKey field from HTTPAuth struct**
+
+In `go-framework/config/hertz/config.go`, delete line 35:
+
+```go
+// HTTPAuth 鉴权配置
+type HTTPAuth struct {
+	Enable bool   `json:"enable"  yaml:"enable"`
+	AK     string `json:"ak"  yaml:"ak"`
+	SK     string `json:"sk"  yaml:"sk"`
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Volumes/SSD/workspace/github.com/byx-darwin/go-tools && go test ./go-framework/config/hertz/... -count=1 -v`
+
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go-framework/config/hertz/config.go go-framework/config/hertz/config_test.go
+git commit -m "refactor(go-framework): remove orphaned HTTPAuth.TeaKey field
+
+TeaKey was left over from the TEA encryption removal (#25, PR #45).
+The AK/SK auth middleware uses pure HMAC-SHA256 and never reads this field.
+yaml.Unmarshal ignores unknown fields so existing configs are unaffected.
+
+Closes #46"
+```
+
+---
+
+### Task 2: Clean up example references
+
+**Files:**
+- Modify: `example/handler/config_handler.go:204`
+- Modify: `example/config.yaml:71`
+
+**Interfaces:**
+- Consumes: Task 1 completed (TeaKey field removed)
+- Produces: No remaining `tea_key` references in example code
+
+- [ ] **Step 1: Remove "tea_key" from sensitive field mask list**
+
+In `example/handler/config_handler.go:204`, change:
+
+```go
+for _, s := range []string{"secret", "password", "token", "sk", "tea_key", "app_key"} {
+```
+
+to:
+
+```go
+for _, s := range []string{"secret", "password", "token", "sk", "app_key"} {
+```
+
+- [ ] **Step 2: Remove tea_key line from example config**
+
+In `example/config.yaml`, delete line 71 (`tea_key: "0123456789abcdef"`). The auth section becomes:
+
+```yaml
+  auth:
+    enable: true
+    ak: "example-ak"
+    sk: "example-sk"
+```
+
+- [ ] **Step 3: Verify no remaining tea_key references**
+
+Run: `cd /Volumes/SSD/workspace/github.com/byx-darwin/go-tools && grep -rn "TeaKey\|tea_key" --include="*.go" --include="*.yaml" --include="*.yml" .`
+
+Expected: No output (zero matches in Go/YAML files; docs/specs references are acceptable)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add example/handler/config_handler.go example/config.yaml
+git commit -m "chore(example): remove tea_key from sensitive mask list and example config"
+```
+
+---
+
+### Task 3: Full validation
+
+**Files:** None (validation only)
+
+- [ ] **Step 1: Build all modules**
+
+Run: `cd /Volumes/SSD/workspace/github.com/byx-darwin/go-tools && go build ./go-common/... ./go-auth/... ./go-middleware/... ./go-framework/...`
+
+Expected: No errors
+
+- [ ] **Step 2: Vet**
+
+Run: `cd /Volumes/SSD/workspace/github.com/byx-darwin/go-tools && go vet ./go-common/... ./go-auth/... ./go-middleware/... ./go-framework/...`
+
+Expected: No issues
+
+- [ ] **Step 3: Lint go-framework module**
+
+Run: `cd /Volumes/SSD/workspace/github.com/byx-darwin/go-tools && golangci-lint run --timeout=5m ./go-framework/...`
+
+Expected: No issues
+
+- [ ] **Step 4: Run go-framework tests**
+
+Run: `cd /Volumes/SSD/workspace/github.com/byx-darwin/go-tools && go test ./go-framework/... -count=1`
+
+Expected: ALL PASS
+
+- [ ] **Step 5: Run full workspace tests**
+
+Run: `cd /Volumes/SSD/workspace/github.com/byx-darwin/go-tools && go test ./go-common/... ./go-auth/... ./go-middleware/... ./go-framework/... -count=1`
+
+Expected: ALL PASS

--- a/docs/superpowers/specs/2026-07-22-remove-httpauth-teakey-design.md
+++ b/docs/superpowers/specs/2026-07-22-remove-httpauth-teakey-design.md
@@ -1,0 +1,69 @@
+# 设计文档：删除 HTTPAuth.TeaKey 孤儿配置字段
+
+- **Issue**: #46
+- **日期**: 2026-07-22
+- **决策**: 方案 B — 删除字段
+- **关联**: #25 (TEA→AES-GCM) · PR #45 · #34 (审计修复路线图)
+
+## 背景
+
+`go-common` 的 TEA 加密已在 #25（PR #45）中彻底移除并迁移到 AES-GCM。
+`go-framework/config/hertz/config.go` 中残留一个指向 TEA 的配置字段：
+
+```go
+type HTTPAuth struct {
+    Enable bool   `json:"enable"  yaml:"enable"`
+    AK     string `json:"ak"  yaml:"ak"`
+    SK     string `json:"sk"  yaml:"sk"`
+    TeaKey string `json:"tea_key"  yaml:"tea_key"`   // ← 孤儿字段
+}
+```
+
+### 代码分析结论
+
+| 检查项 | 结果 |
+|--------|------|
+| 全仓库 `TeaKey` 功能性读取 | **零** — 无任何代码用它做加密 |
+| AK/SK 鉴权中间件 (`middleware/auth.go`) | 纯 HMAC-SHA256 签名验证，不使用对称加密密钥 |
+| 唯一其他引用 | `example/handler/config_handler.go:204` 脱敏清单中的字符串 `"tea_key"` |
+| YAML 反序列化 | `config.LoadYAML` 使用 `yaml.Unmarshal`（非 strict 模式），忽略未知字段 |
+
+### 决策依据
+
+选择 **方案 B（删除）** 而非改名复用（A）或保留重命名（C），原因：
+
+1. AK/SK 鉴权是纯 HMAC 签名机制，不需要对称加密密钥，没有"复用为 AESKey"的场景
+2. 保留一个无功能的字段只会造成语义误导
+3. `yaml.Unmarshal` 不使用 `KnownFields(true)`，旧配置中的 `tea_key:` 会被安全忽略，**不会产生运行时错误**
+
+## 变更范围
+
+### 本仓库（go-tools）
+
+| 文件 | 变更 |
+|------|------|
+| `go-framework/config/hertz/config.go:35` | 删除 `TeaKey` 字段 |
+| `go-framework/config/hertz/config_test.go:32,44` | 移除 `TeaKey` 相关测试断言 |
+| `example/handler/config_handler.go:204` | 从脱敏清单中移除 `"tea_key"` |
+| `example/config.yaml:71` | 删除 `tea_key: "0123456789abcdef"` 行 |
+
+### 不在本次范围（follow-up）
+
+| 项目 | 说明 |
+|------|------|
+| ncgo 脚手架模板 | ncgo 是独立仓库，需单独更新配置模板与示例 YAML |
+| 迁移说明 | 旧 `tea_key` 配置无需手动清理（yaml 忽略未知字段），但建议在 ncgo 更新时附带说明 |
+
+## 向后兼容性
+
+- **YAML 配置兼容**: `yaml.Unmarshal` 忽略未知字段，已部署服务的 `config.yaml` 中残留 `tea_key:` 不会报错
+- **Go 源码兼容**: 这是 source-breaking change — 任何直接引用 `HTTPAuth.TeaKey` 的 Go 代码会编译失败。已确认本仓库内无此类引用
+- **JSON 配置兼容**: 同理，`json.Unmarshal` 忽略未知字段
+
+## 验证标准
+
+- `go build ./go-framework/...` 通过
+- `go vet ./go-framework/...` 通过
+- `golangci-lint run --timeout=5m ./go-framework/...` 通过
+- `go test ./go-framework/... -count=1` 通过
+- 全仓库 `grep -r "TeaKey\|tea_key"` 无残留（设计文档除外）

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -68,7 +68,6 @@ hertz:
     enable: true
     ak: "example-ak"
     sk: "example-sk"
-    tea_key: "0123456789abcdef"
 
 kitex:
   rpc:

--- a/example/handler/config_handler.go
+++ b/example/handler/config_handler.go
@@ -201,7 +201,7 @@ func maskSecrets(m map[string]any) map[string]any {
 // isSensitiveKey 判断 key 是否包含敏感词。
 func isSensitiveKey(key string) bool {
 	lower := strings.ToLower(key)
-	for _, s := range []string{"secret", "password", "token", "sk", "tea_key", "app_key"} {
+	for _, s := range []string{"secret", "password", "token", "sk", "app_key"} {
 		if strings.Contains(lower, s) {
 			return true
 		}

--- a/go-framework/config/hertz/config.go
+++ b/go-framework/config/hertz/config.go
@@ -32,5 +32,4 @@ type HTTPAuth struct {
 	Enable bool   `json:"enable"  yaml:"enable"`
 	AK     string `json:"ak"  yaml:"ak"`
 	SK     string `json:"sk"  yaml:"sk"`
-	TeaKey string `json:"tea_key"  yaml:"tea_key"`
 }

--- a/go-framework/config/hertz/config_test.go
+++ b/go-framework/config/hertz/config_test.go
@@ -29,7 +29,6 @@ func TestServerConfig_Full(t *testing.T) {
 			Enable: true,
 			AK:     "test-ak",
 			SK:     "test-sk",
-			TeaKey: "test-tea-key",
 		},
 	}
 
@@ -41,7 +40,7 @@ func TestServerConfig_Full(t *testing.T) {
 	assert.True(t, c.HTTP.IsRecovery)
 	assert.True(t, c.Auth.Enable)
 	assert.Equal(t, "test-ak", c.Auth.AK)
-	assert.Equal(t, "test-tea-key", c.Auth.TeaKey)
+	assert.Equal(t, "test-sk", c.Auth.SK)
 }
 
 func TestHTTPOption_Mode(t *testing.T) {


### PR DESCRIPTION
## Summary

删除 `HTTPAuth.TeaKey` 孤儿配置字段及其全部引用。

TEA 加密已在 #25（PR #45）中彻底移除并迁移到 AES-GCM，但 `go-framework/config/hertz/config.go` 中残留一个指向 TEA 的配置字段。全仓库检索确认 `TeaKey` **无任何功能性读取**——AK/SK 鉴权中间件是纯 HMAC-SHA256 签名验证，不使用对称加密密钥。

## Changes

| 文件 | 变更 |
|------|------|
| `go-framework/config/hertz/config.go` | 删除 `TeaKey` 字段 |
| `go-framework/config/hertz/config_test.go` | 移除 `TeaKey` 相关断言，新增 `SK` 断言 |
| `example/handler/config_handler.go` | 脱敏清单移除 `"tea_key"` |
| `example/config.yaml` | 删除 `tea_key` 配置行 |

## Backward Compatibility

- `yaml.Unmarshal` 不使用 `KnownFields(true)`，已部署服务配置中残留 `tea_key:` 会被安全忽略，**无运行时错误**
- Source-breaking：直接引用 `HTTPAuth.TeaKey` 的 Go 代码会编译失败（已确认本仓库内无此类引用）

## Validation

- [x] `go build` 全模块通过
- [x] `go vet` 全模块通过
- [x] `go test ./go-framework/... -count=1` 全部通过
- [x] `go test` 全 workspace 通过
- [x] 全仓库 `grep -r "TeaKey|tea_key"` Go/YAML 文件零残留

## Follow-up

- ncgo 脚手架模板更新（独立仓库，单独 Issue）

Closes #46
