### PR TITLE
fix(hertz): protojson 序列化展开 Response.Data 中的 anypb.Any

### DIFF
--- a/go-framework/go.mod
+++ b/go-framework/go.mod
@@ -22,6 +22,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
+	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -90,7 +91,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260618152121-87f3d3e198d3 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260618152121-87f3d3e198d3 // indirect
 	google.golang.org/grpc v1.81.1 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go-framework/hertz/response.go
+++ b/go-framework/hertz/response.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cloudwego/hertz/pkg/protocol/consts"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 )
@@ -232,7 +233,18 @@ func (r *Responder) writeResponse(ctx *app.RequestContext, httpCode int, obj any
 	case consts.MIMEPROTOBUF:
 		ctx.ProtoBuf(httpCode, obj)
 	default:
-		ctx.JSON(httpCode, obj)
+		// JSON 序列化：使用 protojson 以正确展开 anypb.Any
+		if resp, ok := obj.(*Response); ok && resp.Data != nil {
+			jsonBytes, err := protojson.Marshal(resp)
+			if err != nil {
+				// 降级为标准 JSON
+				ctx.JSON(httpCode, obj)
+				return
+			}
+			ctx.Data(httpCode, consts.MIMEApplicationJSONUTF8, jsonBytes)
+		} else {
+			ctx.JSON(httpCode, obj)
+		}
 	}
 }
 
@@ -240,23 +252,28 @@ func (r *Responder) writeResponse(ctx *app.RequestContext, httpCode int, obj any
 
 // reply 内部写响应方法。
 func (r *Responder) reply(ctx *app.RequestContext, httpCode, bizCode int, data any, msg string) {
-	var anyData *anypb.Any
-	if data != nil {
-		if protoMsg, ok := data.(proto.Message); ok {
-			var err error
-			anyData, err = anypb.New(protoMsg)
-			if err != nil {
-				// 如果包装失败，记录错误但继续（data 将为 nil）
-				// TODO: 考虑使用日志记录
-				anyData = nil
-			}
+	// 尝试将 data 包装为 anypb.Any（仅对 protobuf 消息）
+	if protoMsg, ok := data.(proto.Message); ok {
+		anyData, err := anypb.New(protoMsg)
+		if err != nil {
+			// 包装失败，降级为 nil
+			anyData = nil
 		}
-		// 如果 data 不是 Protobuf 消息，anyData 保持为 nil
-		// JSON 序列化时会忽略 nil 字段
+		resp := &Response{Code: int32(bizCode), Msg: msg, Data: anyData}
+		r.writeResponse(ctx, httpCode, resp)
+	} else if data != nil {
+		// 非 protobuf 数据，使用通用 map 结构
+		resp := map[string]any{
+			"code": int32(bizCode),
+			"msg":  msg,
+			"data": data,
+		}
+		r.writeResponse(ctx, httpCode, resp)
+	} else {
+		// data 为 nil，使用 Response 结构（无 data 字段）
+		resp := &Response{Code: int32(bizCode), Msg: msg}
+		r.writeResponse(ctx, httpCode, resp)
 	}
-
-	resp := &Response{Code: int32(bizCode), Msg: msg, Data: anyData}
-	r.writeResponse(ctx, httpCode, resp)
 }
 
 // Success 成功响应。

--- a/go-framework/hertz/response_integration_test.go
+++ b/go-framework/hertz/response_integration_test.go
@@ -64,11 +64,12 @@ func TestResponder_Success_Integration(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, w.Code)
 
-	var resp Response
+	// 非 protobuf 数据使用通用 map 结构序列化
+	var resp map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.Equal(t, int32(http.StatusOK), resp.Code)
-	assert.Equal(t, "ok", resp.Msg)
-	assert.Equal(t, map[string]any{"id": "123"}, resp.Data)
+	assert.Equal(t, float64(http.StatusOK), resp["code"])
+	assert.Equal(t, "ok", resp["msg"])
+	assert.Equal(t, map[string]any{"id": "123"}, resp["data"])
 }
 
 func TestResponder_SuccessWithMsg_Integration(t *testing.T) {
@@ -247,4 +248,31 @@ func TestResponder_WithTranslator(t *testing.T) {
 	var resp Response
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	assert.Equal(t, "已翻译-success_message", resp.Msg)
+}
+
+// ── anypb.Any JSON 展开测试 ──
+
+// TestResponder_Success_ProtoData_AnyExpansion 验证 protobuf 消息作为 data 时，
+// JSON 序列化会展开 anypb.Any（而非 {type_url, value} 原始格式）。
+func TestResponder_Success_ProtoData_AnyExpansion(t *testing.T) {
+	r := NewResponder()
+	engine := route.NewEngine(config.NewOptions([]config.Option{}))
+	engine.Use(r.Middleware())
+	engine.GET("/success-proto", func(ctx context.Context, c *app.RequestContext) {
+		resp := RespondFrom(c)
+		// 使用 Response 作为 protobuf 消息测试数据
+		resp.Success(c, &Response{Code: 1, Msg: "inner"})
+	})
+
+	w := ut.PerformRequest(engine, http.MethodGet, "/success-proto", nil)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	body := w.Body.String()
+	// 验证 anypb.Any 被展开，包含内部字段
+	assert.Contains(t, body, `"code"`)
+	assert.Contains(t, body, `"msg"`)
+	// 不应包含 type_url 和 value 字段（未展开的 anypb.Any 格式）
+	assert.NotContains(t, body, `"type_url"`)
+	assert.NotContains(t, body, `"@"type"`)
 }

--- a/go-framework/hertz/response_integration_test.go
+++ b/go-framework/hertz/response_integration_test.go
@@ -66,7 +66,7 @@ func TestResponder_Success_Integration(t *testing.T) {
 
 	var resp Response
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, int32(http.StatusOK), resp.Code)
 	assert.Equal(t, "ok", resp.Msg)
 	assert.Equal(t, map[string]any{"id": "123"}, resp.Data)
 }
@@ -81,7 +81,7 @@ func TestResponder_SuccessWithMsg_Integration(t *testing.T) {
 
 	var resp Response
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, int32(http.StatusOK), resp.Code)
 	assert.Equal(t, "操作成功", resp.Msg)
 }
 
@@ -97,7 +97,7 @@ func TestResponder_Error_RPCRouting(t *testing.T) {
 
 	var resp Response
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.Equal(t, frameworkerror.CodeParamInvalid, resp.Code)
+	assert.Equal(t, int32(frameworkerror.CodeParamInvalid), resp.Code)
 	assert.Equal(t, "param_invalid", resp.Msg)
 }
 
@@ -111,7 +111,7 @@ func TestResponder_Error_PlainError(t *testing.T) {
 
 	var resp Response
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.Equal(t, http.StatusInternalServerError, resp.Code)
+	assert.Equal(t, int32(http.StatusInternalServerError), resp.Code)
 	assert.Contains(t, resp.Msg, "操作失败")
 }
 
@@ -125,7 +125,7 @@ func TestResponder_ErrorWithCode(t *testing.T) {
 
 	var resp Response
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.Equal(t, 40300, resp.Code)
+	assert.Equal(t, int32(40300), resp.Code)
 	assert.Equal(t, "禁止访问", resp.Msg)
 }
 


### PR DESCRIPTION
## 问题

`Responder.writeResponse` 的 JSON 分支使用 `ctx.JSON`（标准 Go JSON 编码器）序列化 `Response` 对象。当 `Data` 字段为 `*anypb.Any` 时，标准 JSON 无法展开 Any 类型，前端收到的是 `{type_url, value}` 原始格式。

## 修复

- `writeResponse`：当 `obj` 为 `*Response` 且 `Data != nil` 时，使用 `protojson.Marshal` 序列化，正确展开 Any 字段
- `reply`：区分 protobuf 消息（包装为 Any）和非 protobuf 数据（使用通用 map 结构），避免数据丢失

## 测试

- 修复 5 个已有测试断言的类型不匹配（`int` → `int32`）
- 新增 `TestResponder_Success_ProtoData_AnyExpansion` 验证 Any 展开

Closes #52
