### PR TITLE
feat(redis): 新增分布式锁与限流器封装

### DIFF
--- a/docs/superpowers/plans/2026-08-31-redis-lock-limiter.md
+++ b/docs/superpowers/plans/2026-08-31-redis-lock-limiter.md
@@ -1,0 +1,1252 @@
+# Redis 分布式锁与限流器 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在 `go-middleware/redis` 包新增分布式锁（`Mutex`）与限流器（`Limiter`），封装在 `redis.UniversalClient` 之上，供业务项目复用。
+
+**Architecture:** `lock.go` 实现单实例 `SET NX PX` 加锁 + Lua 原子释放脚本 + watchdog 续期 goroutine；`limiter.go` 实现基于 Redis Hash 的令牌桶算法，Lua 脚本原子完成补充/扣减；两者都通过 `redis.UniversalClient` 复用现有连接层，错误统一走 `go-common/error` 的 `oops` 风格。
+
+**Tech Stack:** Go 1.26（workspace `go-middleware` 子模块），`github.com/redis/go-redis/v9`（含 `redis.Script`），`github.com/alicebob/miniredis/v2` v2.38.0（测试用嵌入式 Redis），`github.com/stretchr/testify` v1.12.1。
+
+**Spec:** `docs/superpowers/specs/2026-08-31-redis-lock-limiter-design.md`
+
+## Global Constraints
+
+- 模块边界：仅修改 `go-middleware/redis` 包，不引入对 `go-framework` 的依赖（siblings 规则）。
+- 错误码：新增 `CodeLockAcquire=20103`、`CodeLockRelease=20104`、`CodeLimiterEval=20105`，落在 `go-middleware` 段（20000-20699）内，redis 包自有子段。
+- 所有导出符号（类型/函数/常量）必须有 `// Name ...` 格式的 godoc 注释（revive lint 要求）。
+- 构造函数使用 Functional Options 模式（`NewMutex`/`NewLimiter` 均为 3+ 参数），遵循 `.claude/rules/options-pattern.md`。
+- 测试文件与源码同目录、`package redis`（内部测试包，与现有 `client_test.go`/`config_test.go` 一致），复用 `miniredis.RunT` 模式。
+- `defer f.Close()` 类语句需显式忽略错误（`defer func() { _ = x.Close() }()`），符合 `errcheck` 规则。
+- 每个 Lua 脚本用 `redis.NewScript` 包级变量定义一次，不在函数内重复构造。
+
+---
+
+### Task 1: 扩展错误码（Lock/Limiter）
+
+**Files:**
+- Modify: `go-middleware/redis/errors.go`
+- Modify: `go-middleware/redis/errors_test.go`
+
+**Interfaces:**
+- Produces: `CodeLockAcquire = 20103`、`CodeLockRelease = 20104`、`CodeLimiterEval = 20105`（`int` 常量）；`ErrLockAcquire`、`ErrLockRelease`、`ErrLimiterEval`（`*oops.OopsErrorBuilder`，与现有 `ErrConnect` 同类型）。后续 Task 2-9 直接引用这三个 error 构造器。
+
+- [ ] **Step 1: 写失败测试（新增错误码值 + 构造器 + HTTP 状态映射）**
+
+在 `go-middleware/redis/errors_test.go` 末尾追加：
+
+```go
+// TestLockLimiterCodeValues 码值是 wire 契约，逐值锁定。
+func TestLockLimiterCodeValues(t *testing.T) {
+	assert.Equal(t, 20103, redis.CodeLockAcquire)
+	assert.Equal(t, 20104, redis.CodeLockRelease)
+	assert.Equal(t, 20105, redis.CodeLimiterEval)
+}
+
+// TestLockLimiterPredefinedErrors 构造器 code + public 消息符合预期。
+func TestLockLimiterPredefinedErrors(t *testing.T) {
+	code, public := goerror.Extract(redis.ErrLockAcquire.Wrap(errors.New("x")))
+	assert.Equal(t, 20103, code)
+	assert.Equal(t, "redis_lock_acquire_error", public)
+
+	code, public = goerror.Extract(redis.ErrLockRelease.Wrap(errors.New("x")))
+	assert.Equal(t, 20104, code)
+	assert.Equal(t, "redis_lock_release_error", public)
+
+	code, public = goerror.Extract(redis.ErrLimiterEval.Wrap(errors.New("x")))
+	assert.Equal(t, 20105, code)
+	assert.Equal(t, "redis_limiter_eval_error", public)
+}
+
+// TestLockLimiterHTTPStatusRegistration init() 注册的 HTTP 状态映射。
+func TestLockLimiterHTTPStatusRegistration(t *testing.T) {
+	assert.Equal(t, 409, goerror.HTTPStatus(redis.ErrLockAcquire.Wrap(errors.New("x"))))
+	assert.Equal(t, 409, goerror.HTTPStatus(redis.ErrLockRelease.Wrap(errors.New("x"))))
+	assert.Equal(t, 500, goerror.HTTPStatus(redis.ErrLimiterEval.Wrap(errors.New("x"))))
+}
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `go test ./go-middleware/redis/... -run TestLockLimiter -v`
+Expected: FAIL（`redis.CodeLockAcquire` 等未定义，编译错误）
+
+- [ ] **Step 3: 实现错误码**
+
+将 `go-middleware/redis/errors.go` 替换为：
+
+```go
+package redis
+
+import (
+	goerror "github.com/byx-darwin/go-tools/go-common/error"
+)
+
+// Redis 错误码 20101-20105。
+const (
+	// CodeConnect Redis 连接/Ping 失败
+	CodeConnect = 20101
+	// CodeInstrument Redis OpenTelemetry 埋点初始化失败
+	CodeInstrument = 20102
+	// CodeLockAcquire 分布式锁加锁失败
+	CodeLockAcquire = 20103
+	// CodeLockRelease 分布式锁释放失败（未持有或已过期）
+	CodeLockRelease = 20104
+	// CodeLimiterEval 限流器 Lua 脚本执行失败
+	CodeLimiterEval = 20105
+)
+
+// 预定义 Redis 错误构造器。
+var (
+	// ErrConnect Redis 连接/Ping 失败
+	ErrConnect = goerror.Code(CodeConnect).Public("redis_connect_error")
+	// ErrInstrument Redis OpenTelemetry 埋点初始化失败
+	ErrInstrument = goerror.Code(CodeInstrument).Public("redis_instrument_error")
+	// ErrLockAcquire 分布式锁加锁失败
+	ErrLockAcquire = goerror.Code(CodeLockAcquire).Public("redis_lock_acquire_error")
+	// ErrLockRelease 分布式锁释放失败
+	ErrLockRelease = goerror.Code(CodeLockRelease).Public("redis_lock_release_error")
+	// ErrLimiterEval 限流器 Lua 脚本执行失败
+	ErrLimiterEval = goerror.Code(CodeLimiterEval).Public("redis_limiter_eval_error")
+)
+
+// init 注册 Redis 错误码的细粒度 HTTP 状态码映射。
+func init() {
+	goerror.RegisterHTTPStatuses(map[int]int{
+		CodeConnect:     503,
+		CodeInstrument:  500,
+		CodeLockAcquire: 409,
+		CodeLockRelease: 409,
+		CodeLimiterEval: 500,
+	})
+}
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `go test ./go-middleware/redis/... -run TestLockLimiter -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go-middleware/redis/errors.go go-middleware/redis/errors_test.go
+git commit -m "feat(redis): add error codes for lock and limiter (#56)"
+```
+
+---
+
+### Task 2: Mutex 骨架 + Options（构造器，不含加锁逻辑）
+
+**Files:**
+- Create: `go-middleware/redis/lock.go`
+- Create: `go-middleware/redis/lock_test.go`
+
+**Interfaces:**
+- Consumes: `redis.UniversalClient`（`go-redis/v9`）
+- Produces：
+  - `type Mutex struct { client redis.UniversalClient; key string; ttl time.Duration; retryInterval time.Duration; watchdog bool; mu sync.Mutex; token string; stopCh chan struct{} }`
+  - `func NewMutex(client redis.UniversalClient, key string, opts ...MutexOption) *Mutex`
+  - `type MutexOption func(*mutexOptions)`
+  - `func WithTTL(ttl time.Duration) MutexOption`
+  - `func WithRetryInterval(interval time.Duration) MutexOption`
+  - `func WithWatchdog(enabled bool) MutexOption`
+  - 后续 Task 3-6 在此文件基础上追加 `TryLock`/`Unlock`/`Lock`/watchdog 方法
+
+- [ ] **Step 1: 写失败测试（默认值 + Options 覆盖）**
+
+创建 `go-middleware/redis/lock_test.go`：
+
+```go
+package redis
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	goredis "github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestRedisClient(t *testing.T) (*miniredis.Miniredis, goredis.UniversalClient) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := goredis.NewClient(&goredis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	return mr, client
+}
+
+func TestNewMutex_Defaults(t *testing.T) {
+	_, client := newTestRedisClient(t)
+
+	m := NewMutex(client, "lock:test")
+
+	assert.Equal(t, "lock:test", m.key)
+	assert.Equal(t, defaultMutexTTL, m.ttl)
+	assert.Equal(t, defaultRetryInterval, m.retryInterval)
+	assert.True(t, m.watchdog)
+}
+
+func TestNewMutex_CustomOptions(t *testing.T) {
+	_, client := newTestRedisClient(t)
+
+	m := NewMutex(client, "lock:test",
+		WithTTL(5*time.Second),
+		WithRetryInterval(20*time.Millisecond),
+		WithWatchdog(false),
+	)
+
+	assert.Equal(t, 5*time.Second, m.ttl)
+	assert.Equal(t, 20*time.Millisecond, m.retryInterval)
+	assert.False(t, m.watchdog)
+}
+
+func TestMutexOption_IgnoresInvalidValues(t *testing.T) {
+	_, client := newTestRedisClient(t)
+
+	m := NewMutex(client, "lock:test", WithTTL(0), WithRetryInterval(-1))
+
+	assert.Equal(t, defaultMutexTTL, m.ttl)
+	assert.Equal(t, defaultRetryInterval, m.retryInterval)
+}
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `go test ./go-middleware/redis/... -run TestNewMutex -v`
+Expected: FAIL（`lock.go` 不存在，`NewMutex`/`defaultMutexTTL` 未定义）
+
+- [ ] **Step 3: 实现 Mutex 骨架**
+
+创建 `go-middleware/redis/lock.go`：
+
+```go
+package redis
+
+import (
+	"sync"
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+)
+
+const (
+	defaultMutexTTL      = 10 * time.Second
+	defaultRetryInterval = 100 * time.Millisecond
+)
+
+// Mutex 基于 Redis 的分布式互斥锁（单实例 SET NX PX 方案），不支持可重入。
+// 一个 Mutex 实例代表一次加锁会话：Lock/TryLock 成功后必须调用 Unlock 才能再次加锁。
+type Mutex struct {
+	client        goredis.UniversalClient
+	key           string
+	ttl           time.Duration
+	retryInterval time.Duration
+	watchdog      bool
+
+	mu     sync.Mutex
+	token  string
+	stopCh chan struct{}
+}
+
+// MutexOption 定义 Mutex 创建选项。
+type MutexOption func(*mutexOptions)
+
+type mutexOptions struct {
+	ttl           time.Duration
+	retryInterval time.Duration
+	watchdog      bool
+}
+
+// WithTTL 设置锁的过期时间（必须 > 0，否则忽略，保留默认值）。
+func WithTTL(ttl time.Duration) MutexOption {
+	return func(o *mutexOptions) {
+		if ttl > 0 {
+			o.ttl = ttl
+		}
+	}
+}
+
+// WithRetryInterval 设置 Lock 阻塞重试的轮询间隔（必须 > 0，否则忽略）。
+func WithRetryInterval(interval time.Duration) MutexOption {
+	return func(o *mutexOptions) {
+		if interval > 0 {
+			o.retryInterval = interval
+		}
+	}
+}
+
+// WithWatchdog 设置是否启用续期 watchdog（默认 true）。
+func WithWatchdog(enabled bool) MutexOption {
+	return func(o *mutexOptions) {
+		o.watchdog = enabled
+	}
+}
+
+// NewMutex 创建分布式锁实例。
+// 默认配置：ttl=10s，retryInterval=100ms，watchdog=true。
+func NewMutex(client goredis.UniversalClient, key string, opts ...MutexOption) *Mutex {
+	o := &mutexOptions{
+		ttl:           defaultMutexTTL,
+		retryInterval: defaultRetryInterval,
+		watchdog:      true,
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+	return &Mutex{
+		client:        client,
+		key:           key,
+		ttl:           o.ttl,
+		retryInterval: o.retryInterval,
+		watchdog:      o.watchdog,
+	}
+}
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `go test ./go-middleware/redis/... -run TestNewMutex -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go-middleware/redis/lock.go go-middleware/redis/lock_test.go
+git commit -m "feat(redis): add Mutex constructor and options (#56)"
+```
+
+---
+
+### Task 3: TryLock（非阻塞加锁）
+
+**Files:**
+- Modify: `go-middleware/redis/lock.go`
+- Modify: `go-middleware/redis/lock_test.go`
+
+**Interfaces:**
+- Consumes: Task 2 的 `Mutex` 结构体字段（`client`/`key`/`ttl`/`mu`/`token`）、`ErrLockAcquire`（Task 1）
+- Produces: `func (m *Mutex) TryLock(ctx context.Context) (bool, error)`；内部 helper `func randomToken() (string, error)`。Task 4（Unlock）、Task 5（Lock）、Task 6（watchdog）依赖 `m.token` 由 `TryLock` 写入。
+
+- [ ] **Step 1: 写失败测试**
+
+在 `lock_test.go` 追加：
+
+```go
+func TestMutex_TryLock_Success(t *testing.T) {
+	_, client := newTestRedisClient(t)
+	m := NewMutex(client, "lock:trylock", WithWatchdog(false))
+
+	ok, err := m.TryLock(context.Background())
+
+	assert.NoError(t, err)
+	assert.True(t, ok)
+	assert.NotEmpty(t, m.token)
+}
+
+func TestMutex_TryLock_AlreadyHeld(t *testing.T) {
+	_, client := newTestRedisClient(t)
+	first := NewMutex(client, "lock:contested", WithWatchdog(false))
+	second := NewMutex(client, "lock:contested", WithWatchdog(false))
+
+	ok1, err1 := first.TryLock(context.Background())
+	require.NoError(t, err1)
+	require.True(t, ok1)
+
+	ok2, err2 := second.TryLock(context.Background())
+
+	assert.NoError(t, err2)
+	assert.False(t, ok2)
+}
+```
+
+顶部 import 追加 `"context"` 和 `"github.com/stretchr/testify/require"`。
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `go test ./go-middleware/redis/... -run TestMutex_TryLock -v`
+Expected: FAIL（`TryLock` 未定义）
+
+- [ ] **Step 3: 实现 TryLock**
+
+在 `lock.go` 追加 import（`"context"`、`"crypto/rand"`、`"encoding/hex"`）并追加：
+
+```go
+func randomToken() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// TryLock 单次非阻塞尝试获取锁。成功后若启用 watchdog 会自动启动续期。
+func (m *Mutex) TryLock(ctx context.Context) (bool, error) {
+	token, err := randomToken()
+	if err != nil {
+		return false, ErrLockAcquire.Wrap(err)
+	}
+
+	ok, err := m.client.SetNX(ctx, m.key, token, m.ttl).Result()
+	if err != nil {
+		return false, ErrLockAcquire.Wrap(err)
+	}
+	if !ok {
+		return false, nil
+	}
+
+	m.mu.Lock()
+	m.token = token
+	m.mu.Unlock()
+
+	if m.watchdog {
+		m.startWatchdog()
+	}
+	return true, nil
+}
+
+// startWatchdog 在 Task 6 中实现；此处先占位为空操作以保证 TryLock 可编译独立测试。
+func (m *Mutex) startWatchdog() {}
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `go test ./go-middleware/redis/... -run TestMutex_TryLock -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go-middleware/redis/lock.go go-middleware/redis/lock_test.go
+git commit -m "feat(redis): implement Mutex.TryLock (#56)"
+```
+
+---
+
+### Task 4: Unlock（Lua 原子释放）
+
+**Files:**
+- Modify: `go-middleware/redis/lock.go`
+- Modify: `go-middleware/redis/lock_test.go`
+
+**Interfaces:**
+- Consumes: Task 3 的 `TryLock`、`m.token`、`ErrLockRelease`（Task 1）
+- Produces: `func (m *Mutex) Unlock(ctx context.Context) error`；包级变量 `var releaseScript = goredis.NewScript(...)`。Task 6 的 watchdog 停止逻辑会替换本任务中 `Unlock` 里对 `stopWatchdog` 的占位调用。
+
+- [ ] **Step 1: 写失败测试**
+
+在 `lock_test.go` 追加：
+
+```go
+func TestMutex_Unlock_Success(t *testing.T) {
+	_, client := newTestRedisClient(t)
+	m := NewMutex(client, "lock:unlock", WithWatchdog(false))
+	ctx := context.Background()
+
+	ok, err := m.TryLock(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	err = m.Unlock(ctx)
+
+	assert.NoError(t, err)
+
+	exists, err := client.Exists(ctx, "lock:unlock").Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), exists)
+}
+
+func TestMutex_Unlock_NotHeld(t *testing.T) {
+	_, client := newTestRedisClient(t)
+	m := NewMutex(client, "lock:notheld", WithWatchdog(false))
+
+	err := m.Unlock(context.Background())
+
+	assert.ErrorIs(t, err, ErrLockRelease)
+}
+
+func TestMutex_Unlock_HeldByOther(t *testing.T) {
+	_, client := newTestRedisClient(t)
+	owner := NewMutex(client, "lock:other", WithWatchdog(false))
+	intruder := NewMutex(client, "lock:other", WithWatchdog(false))
+	ctx := context.Background()
+
+	ok, err := owner.TryLock(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	intruder.mu.Lock()
+	intruder.token = "not-the-real-token"
+	intruder.mu.Unlock()
+
+	err = intruder.Unlock(ctx)
+
+	assert.ErrorIs(t, err, ErrLockRelease)
+
+	exists, err := client.Exists(ctx, "lock:other").Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), exists, "owner's lock must remain untouched")
+}
+```
+
+> 注：`ErrLockRelease` 是 `*oops.OopsErrorBuilder`；`assert.ErrorIs` 依赖 `oops` 的 `Is`/`Unwrap` 实现（与现有 `client_test.go`/`config_test.go` 对 `ErrConnect` 的用法一致，此处沿用同样断言方式）。
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `go test ./go-middleware/redis/... -run TestMutex_Unlock -v`
+Expected: FAIL（`Unlock` 未定义）
+
+- [ ] **Step 3: 实现 Unlock**
+
+在 `lock.go` 顶部追加 import `"errors"`，包级追加：
+
+```go
+var releaseScript = goredis.NewScript(`
+if redis.call('get', KEYS[1]) == ARGV[1] then
+	return redis.call('del', KEYS[1])
+else
+	return 0
+end
+`)
+
+// Unlock 释放锁：停止 watchdog，Lua 脚本校验 token 匹配后删除 key。
+// 若锁未持有、已过期，或被其他持有者持有，返回 ErrLockRelease。
+func (m *Mutex) Unlock(ctx context.Context) error {
+	m.stopWatchdog()
+
+	m.mu.Lock()
+	token := m.token
+	m.mu.Unlock()
+
+	if token == "" {
+		return ErrLockRelease.Wrap(errors.New("lock not held"))
+	}
+
+	res, err := releaseScript.Run(ctx, m.client, []string{m.key}, token).Int64()
+	if err != nil {
+		return ErrLockRelease.Wrap(err)
+	}
+	if res == 0 {
+		return ErrLockRelease.Wrap(errors.New("lock not held or already expired"))
+	}
+
+	m.mu.Lock()
+	m.token = ""
+	m.mu.Unlock()
+	return nil
+}
+
+// stopWatchdog 在 Task 6 中实现完整逻辑；此处先占位为空操作。
+func (m *Mutex) stopWatchdog() {}
+```
+
+将 Task 3 遗留的 `func (m *Mutex) startWatchdog() {}` 占位保留不变（Task 6 会替换其实现）。
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `go test ./go-middleware/redis/... -run TestMutex_Unlock -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go-middleware/redis/lock.go go-middleware/redis/lock_test.go
+git commit -m "feat(redis): implement Mutex.Unlock with Lua release script (#56)"
+```
+
+---
+
+### Task 5: Lock（阻塞重试）
+
+**Files:**
+- Modify: `go-middleware/redis/lock.go`
+- Modify: `go-middleware/redis/lock_test.go`
+
+**Interfaces:**
+- Consumes: Task 3 的 `TryLock`、`ErrLockAcquire`（Task 1）、`m.retryInterval`（Task 2）
+- Produces: `func (m *Mutex) Lock(ctx context.Context) error`
+
+- [ ] **Step 1: 写失败测试**
+
+在 `lock_test.go` 追加：
+
+```go
+func TestMutex_Lock_WaitsForRelease(t *testing.T) {
+	_, client := newTestRedisClient(t)
+	ctx := context.Background()
+	holder := NewMutex(client, "lock:wait", WithWatchdog(false), WithRetryInterval(10*time.Millisecond))
+	waiter := NewMutex(client, "lock:wait", WithWatchdog(false), WithRetryInterval(10*time.Millisecond))
+
+	ok, err := holder.TryLock(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- waiter.Lock(ctx)
+	}()
+
+	time.Sleep(30 * time.Millisecond)
+	require.NoError(t, holder.Unlock(ctx))
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("waiter.Lock did not return after holder released the lock")
+	}
+}
+
+func TestMutex_Lock_ContextCanceled(t *testing.T) {
+	_, client := newTestRedisClient(t)
+	holder := NewMutex(client, "lock:cancel", WithWatchdog(false))
+	waiter := NewMutex(client, "lock:cancel", WithWatchdog(false), WithRetryInterval(10*time.Millisecond))
+
+	ok, err := holder.TryLock(context.Background())
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	err = waiter.Lock(ctx)
+
+	assert.ErrorIs(t, err, ErrLockAcquire)
+}
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `go test ./go-middleware/redis/... -run TestMutex_Lock -v`
+Expected: FAIL（`Lock` 未定义）
+
+- [ ] **Step 3: 实现 Lock**
+
+在 `lock.go` 追加：
+
+```go
+// Lock 阻塞获取锁，直到成功或 ctx 取消。成功后自动启动 watchdog（若启用）。
+func (m *Mutex) Lock(ctx context.Context) error {
+	ticker := time.NewTicker(m.retryInterval)
+	defer ticker.Stop()
+
+	for {
+		ok, err := m.TryLock(ctx)
+		if err != nil {
+			return err
+		}
+		if ok {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ErrLockAcquire.Wrap(ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `go test ./go-middleware/redis/... -run TestMutex_Lock -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go-middleware/redis/lock.go go-middleware/redis/lock_test.go
+git commit -m "feat(redis): implement Mutex.Lock blocking retry (#56)"
+```
+
+---
+
+### Task 6: Watchdog 续期
+
+**Files:**
+- Modify: `go-middleware/redis/lock.go`
+- Modify: `go-middleware/redis/lock_test.go`
+
+**Interfaces:**
+- Consumes: Task 3/4 中 `startWatchdog`/`stopWatchdog` 占位、`m.stopCh`（Task 2 已声明字段）
+- Produces: `startWatchdog`/`stopWatchdog` 的完整实现；包级变量 `var renewScript = goredis.NewScript(...)`
+
+- [ ] **Step 1: 写失败测试**
+
+在 `lock_test.go` 追加（使用 `miniredis.FastForward` 模拟时间流逝，验证续期后锁未过期；以及关闭 watchdog 时锁按 TTL 正常过期）：
+
+```go
+func TestMutex_Watchdog_RenewsBeforeExpiry(t *testing.T) {
+	mr, client := newTestRedisClient(t)
+	ctx := context.Background()
+	m := NewMutex(client, "lock:watchdog", WithTTL(90*time.Millisecond), WithWatchdog(true))
+
+	ok, err := m.TryLock(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// 90ms TTL，续期间隔 = ttl/3 = 30ms。累计推进 200ms（> 原始 TTL），
+	// 若续期生效，key 应仍然存在。
+	for i := 0; i < 10; i++ {
+		mr.FastForward(20 * time.Millisecond)
+		time.Sleep(5 * time.Millisecond) // 让 watchdog goroutine 有机会真实执行一次续期
+	}
+
+	exists, err := client.Exists(ctx, "lock:watchdog").Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), exists, "watchdog should have renewed the lock before its original TTL")
+
+	require.NoError(t, m.Unlock(ctx))
+}
+
+func TestMutex_Watchdog_StopsAfterUnlock(t *testing.T) {
+	mr, client := newTestRedisClient(t)
+	ctx := context.Background()
+	m := NewMutex(client, "lock:watchdog-stop", WithTTL(50*time.Millisecond), WithWatchdog(true))
+
+	ok, err := m.TryLock(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NoError(t, m.Unlock(ctx))
+
+	mr.FastForward(200 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
+
+	exists, err := client.Exists(ctx, "lock:watchdog-stop").Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), exists, "key must not be recreated after Unlock stopped the watchdog")
+}
+
+func TestMutex_Watchdog_Disabled_LockExpires(t *testing.T) {
+	mr, client := newTestRedisClient(t)
+	ctx := context.Background()
+	m := NewMutex(client, "lock:no-watchdog", WithTTL(50*time.Millisecond), WithWatchdog(false))
+
+	ok, err := m.TryLock(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	mr.FastForward(60 * time.Millisecond)
+
+	exists, err := client.Exists(ctx, "lock:no-watchdog").Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), exists)
+}
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `go test ./go-middleware/redis/... -run TestMutex_Watchdog -v`
+Expected: FAIL（`TestMutex_Watchdog_RenewsBeforeExpiry` 失败：key 已过期，因为 `startWatchdog`/`stopWatchdog` 仍是空实现）
+
+- [ ] **Step 3: 实现 watchdog**
+
+在 `lock.go` 中，将 Task 3 的 `func (m *Mutex) startWatchdog() {}` 和 Task 4 的 `func (m *Mutex) stopWatchdog() {}` 占位整体替换为：
+
+```go
+var renewScript = goredis.NewScript(`
+if redis.call('get', KEYS[1]) == ARGV[1] then
+	return redis.call('pexpire', KEYS[1], ARGV[2])
+else
+	return 0
+end
+`)
+
+// startWatchdog 启动后台续期 goroutine：按 ttl/3 周期执行 Lua 续期脚本，
+// 直到 stopWatchdog 被调用或续期失败（锁已丢失）。
+func (m *Mutex) startWatchdog() {
+	stop := make(chan struct{})
+	m.mu.Lock()
+	m.stopCh = stop
+	m.mu.Unlock()
+
+	interval := m.ttl / 3
+	if interval <= 0 {
+		interval = time.Millisecond
+	}
+
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				m.mu.Lock()
+				token := m.token
+				m.mu.Unlock()
+				if token == "" {
+					return
+				}
+
+				res, err := renewScript.Run(context.Background(), m.client, []string{m.key}, token, m.ttl.Milliseconds()).Int64()
+				if err != nil || res == 0 {
+					return
+				}
+			}
+		}
+	}()
+}
+
+// stopWatchdog 停止续期 goroutine（幂等，可安全重复调用）。
+func (m *Mutex) stopWatchdog() {
+	m.mu.Lock()
+	stop := m.stopCh
+	m.stopCh = nil
+	m.mu.Unlock()
+
+	if stop != nil {
+		close(stop)
+	}
+}
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `go test ./go-middleware/redis/... -run TestMutex -v`
+Expected: PASS（全部 Mutex 相关用例，包括 Task 2-6）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go-middleware/redis/lock.go go-middleware/redis/lock_test.go
+git commit -m "feat(redis): implement Mutex watchdog renewal (#56)"
+```
+
+---
+
+### Task 7: Limiter 骨架 + Options（构造器）
+
+**Files:**
+- Create: `go-middleware/redis/limiter.go`
+- Create: `go-middleware/redis/limiter_test.go`
+
+**Interfaces:**
+- Consumes: `redis.UniversalClient`
+- Produces：
+  - `type Limiter struct { client redis.UniversalClient; key string; rate float64; burst int; waitPollInterval time.Duration }`
+  - `func NewLimiter(client redis.UniversalClient, key string, r float64, burst int, opts ...LimiterOption) *Limiter`
+  - `type LimiterOption func(*limiterOptions)`
+  - `func WithWaitPollInterval(interval time.Duration) LimiterOption`
+  - Task 8-9 在此文件追加 `Allow`/`AllowN`/`Wait` 方法
+
+- [ ] **Step 1: 写失败测试**
+
+创建 `go-middleware/redis/limiter_test.go`：
+
+```go
+package redis
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewLimiter_Defaults(t *testing.T) {
+	_, client := newTestRedisClient(t)
+
+	l := NewLimiter(client, "limiter:test", 10, 5)
+
+	assert.Equal(t, "limiter:test", l.key)
+	assert.InDelta(t, 10.0, l.rate, 0.0001)
+	assert.Equal(t, 5, l.burst)
+	assert.Equal(t, defaultWaitPollInterval, l.waitPollInterval)
+}
+
+func TestNewLimiter_CustomOptions(t *testing.T) {
+	_, client := newTestRedisClient(t)
+
+	l := NewLimiter(client, "limiter:test", 10, 5, WithWaitPollInterval(200*time.Millisecond))
+
+	assert.Equal(t, 200*time.Millisecond, l.waitPollInterval)
+}
+
+func TestLimiterOption_IgnoresInvalidValues(t *testing.T) {
+	_, client := newTestRedisClient(t)
+
+	l := NewLimiter(client, "limiter:test", 10, 5, WithWaitPollInterval(0))
+
+	assert.Equal(t, defaultWaitPollInterval, l.waitPollInterval)
+}
+```
+
+（`newTestRedisClient` 复用 Task 2 在 `lock_test.go` 中定义的 helper，同包内可直接调用。）
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `go test ./go-middleware/redis/... -run TestNewLimiter -v`
+Expected: FAIL（`limiter.go` 不存在）
+
+- [ ] **Step 3: 实现 Limiter 骨架**
+
+创建 `go-middleware/redis/limiter.go`：
+
+```go
+package redis
+
+import (
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+)
+
+const defaultWaitPollInterval = 50 * time.Millisecond
+
+// Limiter 基于 Redis 的分布式令牌桶限流器。
+// 方法命名对齐 golang.org/x/time/rate.Limiter（Allow/AllowN/Wait），
+// 但因跨网络调用 Redis，签名带 ctx 且返回 error。
+type Limiter struct {
+	client           goredis.UniversalClient
+	key              string
+	rate             float64
+	burst            int
+	waitPollInterval time.Duration
+}
+
+// LimiterOption 定义 Limiter 创建选项。
+type LimiterOption func(*limiterOptions)
+
+type limiterOptions struct {
+	waitPollInterval time.Duration
+}
+
+// WithWaitPollInterval 设置 Wait 轮询重试间隔（必须 > 0，否则忽略）。
+func WithWaitPollInterval(interval time.Duration) LimiterOption {
+	return func(o *limiterOptions) {
+		if interval > 0 {
+			o.waitPollInterval = interval
+		}
+	}
+}
+
+// NewLimiter 创建分布式限流器。r 为每秒生成令牌数，burst 为桶容量。
+// 默认配置：waitPollInterval=50ms。
+func NewLimiter(client goredis.UniversalClient, key string, r float64, burst int, opts ...LimiterOption) *Limiter {
+	o := &limiterOptions{waitPollInterval: defaultWaitPollInterval}
+	for _, opt := range opts {
+		opt(o)
+	}
+	return &Limiter{
+		client:           client,
+		key:              key,
+		rate:             r,
+		burst:            burst,
+		waitPollInterval: o.waitPollInterval,
+	}
+}
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `go test ./go-middleware/redis/... -run TestNewLimiter -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go-middleware/redis/limiter.go go-middleware/redis/limiter_test.go
+git commit -m "feat(redis): add Limiter constructor and options (#56)"
+```
+
+---
+
+### Task 8: AllowN/Allow（令牌桶 Lua 脚本）
+
+**Files:**
+- Modify: `go-middleware/redis/limiter.go`
+- Modify: `go-middleware/redis/limiter_test.go`
+
+**Interfaces:**
+- Consumes: Task 7 的 `Limiter` 字段、`ErrLimiterEval`（Task 1）
+- Produces: `func (l *Limiter) AllowN(ctx context.Context, n int) (bool, error)`、`func (l *Limiter) Allow(ctx context.Context) (bool, error)`；内部 helper `func (l *Limiter) ttlMillis() int64`；包级变量 `var tokenBucketScript = goredis.NewScript(...)`。Task 9（Wait）依赖 `Allow`。
+
+- [ ] **Step 1: 写失败测试**
+
+在 `limiter_test.go` 追加：
+
+```go
+func TestLimiter_AllowN_WithinBurst(t *testing.T) {
+	_, client := newTestRedisClient(t)
+	ctx := context.Background()
+	l := NewLimiter(client, "limiter:burst", 1, 3)
+
+	for i := 0; i < 3; i++ {
+		ok, err := l.Allow(ctx)
+		require.NoError(t, err)
+		assert.True(t, ok, "request %d within burst should be allowed", i)
+	}
+
+	ok, err := l.Allow(ctx)
+	require.NoError(t, err)
+	assert.False(t, ok, "request beyond burst should be rejected")
+}
+
+func TestLimiter_AllowN_RejectsWhenInsufficientTokens(t *testing.T) {
+	_, client := newTestRedisClient(t)
+	ctx := context.Background()
+	l := NewLimiter(client, "limiter:allown", 1, 5)
+
+	ok, err := l.AllowN(ctx, 3)
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	ok, err = l.AllowN(ctx, 3)
+	require.NoError(t, err)
+	assert.False(t, ok, "only 2 tokens remain, requesting 3 must fail")
+}
+
+func TestLimiter_Refill_OverTime(t *testing.T) {
+	mr, client := newTestRedisClient(t)
+	ctx := context.Background()
+	l := NewLimiter(client, "limiter:refill", 10, 1) // 10 tokens/sec, burst=1
+
+	ok, err := l.Allow(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	ok, err = l.Allow(ctx)
+	require.NoError(t, err)
+	require.False(t, ok, "bucket should be empty immediately after consuming the single token")
+
+	mr.FastForward(200 * time.Millisecond) // 10 tokens/sec * 0.2s = 2 tokens, capped at burst=1
+
+	ok, err = l.Allow(ctx)
+	require.NoError(t, err)
+	assert.True(t, ok, "token should have refilled after 200ms at rate=10/s")
+}
+```
+
+顶部 import 追加 `"context"` 和 `"github.com/stretchr/testify/require"`。
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `go test ./go-middleware/redis/... -run TestLimiter -v`
+Expected: FAIL（`AllowN`/`Allow` 未定义）
+
+- [ ] **Step 3: 实现 AllowN/Allow**
+
+在 `limiter.go` 顶部追加 import `"context"`，包级追加：
+
+```go
+var tokenBucketScript = goredis.NewScript(`
+local tokens_key = KEYS[1]
+local rate = tonumber(ARGV[1])
+local burst = tonumber(ARGV[2])
+local now = tonumber(ARGV[3])
+local requested = tonumber(ARGV[4])
+local ttl = tonumber(ARGV[5])
+
+local data = redis.call('hmget', tokens_key, 'tokens', 'last_refill_ts')
+local tokens = tonumber(data[1])
+local last_refill_ts = tonumber(data[2])
+
+if tokens == nil then
+	tokens = burst
+	last_refill_ts = now
+end
+
+local elapsed = math.max(0, now - last_refill_ts)
+local refill = (elapsed / 1000) * rate
+tokens = math.min(burst, tokens + refill)
+
+local allowed = 0
+if tokens >= requested then
+	tokens = tokens - requested
+	allowed = 1
+end
+
+redis.call('hmset', tokens_key, 'tokens', tokens, 'last_refill_ts', now)
+redis.call('pexpire', tokens_key, ttl)
+
+return allowed
+`)
+
+// Allow 等价于 AllowN(ctx, 1)。
+func (l *Limiter) Allow(ctx context.Context) (bool, error) {
+	return l.AllowN(ctx, 1)
+}
+
+// AllowN 尝试消耗 n 个令牌，返回是否成功。
+func (l *Limiter) AllowN(ctx context.Context, n int) (bool, error) {
+	now := time.Now().UnixMilli()
+	res, err := tokenBucketScript.Run(ctx, l.client, []string{l.key}, l.rate, l.burst, now, n, l.ttlMillis()).Int64()
+	if err != nil {
+		return false, ErrLimiterEval.Wrap(err)
+	}
+	return res == 1, nil
+}
+
+// ttlMillis 计算 bucket key 的过期时间（约为完全补满所需时间的 2 倍，至少 1 秒），
+// 避免闲置 key 常驻内存。
+func (l *Limiter) ttlMillis() int64 {
+	seconds := 2 * (float64(l.burst) / l.rate)
+	if seconds < 1 {
+		seconds = 1
+	}
+	return int64(seconds * 1000)
+}
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `go test ./go-middleware/redis/... -run TestLimiter -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go-middleware/redis/limiter.go go-middleware/redis/limiter_test.go
+git commit -m "feat(redis): implement Limiter token bucket via Lua script (#56)"
+```
+
+---
+
+### Task 9: Wait（阻塞等待令牌）
+
+**Files:**
+- Modify: `go-middleware/redis/limiter.go`
+- Modify: `go-middleware/redis/limiter_test.go`
+
+**Interfaces:**
+- Consumes: Task 8 的 `Allow`、`l.waitPollInterval`（Task 7）
+- Produces: `func (l *Limiter) Wait(ctx context.Context) error`
+
+- [ ] **Step 1: 写失败测试**
+
+在 `limiter_test.go` 追加：
+
+```go
+func TestLimiter_Wait_SucceedsAfterRefill(t *testing.T) {
+	_, client := newTestRedisClient(t)
+	ctx := context.Background()
+	l := NewLimiter(client, "limiter:wait", 100, 1, WithWaitPollInterval(5*time.Millisecond)) // fast refill for test speed
+
+	ok, err := l.Allow(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	waitCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+
+	err = l.Wait(waitCtx)
+
+	assert.NoError(t, err, "Wait should succeed once tokens refill at rate=100/s")
+}
+
+func TestLimiter_Wait_ContextTimeout(t *testing.T) {
+	_, client := newTestRedisClient(t)
+	ctx := context.Background()
+	l := NewLimiter(client, "limiter:wait-timeout", 0.001, 1, WithWaitPollInterval(5*time.Millisecond)) // effectively never refills within test window
+
+	ok, err := l.Allow(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Millisecond)
+	defer cancel()
+
+	err = l.Wait(waitCtx)
+
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `go test ./go-middleware/redis/... -run TestLimiter_Wait -v`
+Expected: FAIL（`Wait` 未定义）
+
+- [ ] **Step 3: 实现 Wait**
+
+在 `limiter.go` 追加：
+
+```go
+// Wait 阻塞直到成功获取 1 个令牌，或 ctx 取消/超时返回其错误。
+func (l *Limiter) Wait(ctx context.Context) error {
+	for {
+		ok, err := l.Allow(ctx)
+		if err != nil {
+			return err
+		}
+		if ok {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(l.waitPollInterval):
+		}
+	}
+}
+```
+
+- [ ] **Step 4: 运行测试确认通过**
+
+Run: `go test ./go-middleware/redis/... -run TestLimiter -v`
+Expected: PASS（全部 Limiter 相关用例，包括 Task 7-9）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go-middleware/redis/limiter.go go-middleware/redis/limiter_test.go
+git commit -m "feat(redis): implement Limiter.Wait (#56)"
+```
+
+---
+
+### Task 10: 全量验证（build / vet / lint / test）
+
+**Files:**
+- None (verification only)
+
+**Interfaces:**
+- Consumes: Task 1-9 的全部产出
+- Produces: 无新代码；确认整个 `go-middleware` 模块可构建、通过静态检查与测试
+
+- [ ] **Step 1: 格式检查**
+
+Run: `gofmt -l go-middleware/redis/`
+Expected: 无输出（无需格式化的文件）
+
+- [ ] **Step 2: 构建**
+
+Run: `go build ./go-middleware/...`
+Expected: 无错误退出
+
+- [ ] **Step 3: vet**
+
+Run: `go vet ./go-middleware/...`
+Expected: 无错误退出
+
+- [ ] **Step 4: lint**
+
+Run: `golangci-lint run --timeout=5m ./go-middleware/...`
+Expected: 无 issue（若报 `errcheck`/`revive` 等问题，按 `.claude/rules/go.md` §8 逐条修复后重跑本步骤）
+
+- [ ] **Step 5: 完整测试**
+
+Run: `go test ./go-middleware/... -count=1 -race`
+Expected: 全部 PASS（含 `-race`，验证 watchdog goroutine 与 `sync.Mutex` 保护的并发安全性）
+
+- [ ] **Step 6: Commit（若 lint/fix 产生改动）**
+
+```bash
+git add -A
+git commit -m "chore(redis): fix lint findings for lock/limiter (#56)"
+```
+
+若 Step 1-5 全部无改动即通过，跳过本步骤（无空提交）。
+
+---
+
+## Self-Review Notes（编写计划时的自查）
+
+- **Spec 覆盖**：设计文档中的 Mutex 结构/Options/加锁/释放/watchdog（Task 2-6）、Limiter 结构/Options/AllowN/Allow/Wait（Task 7-9）、错误码 20103-20105（Task 1）、测试覆盖点（并发竞争 Task 3、非持有者释放 Task 4、watchdog 续期 Task 6、令牌补充 Task 8、Wait 阻塞 Task 9）均有对应任务；README 因包内无独立 README，已在设计文档中明确以 godoc 注释为准（`lock.go`/`limiter.go` 包级类型注释已包含用法说明），不再单列任务。
+- **类型一致性**：`Mutex`/`Limiter` 字段名、`MutexOption`/`LimiterOption`、`WithTTL`/`WithRetryInterval`/`WithWatchdog`/`WithWaitPollInterval` 在各任务间签名一致；`TryLock`/`Lock`/`Unlock`/`Allow`/`AllowN`/`Wait` 的参数与返回类型在跨任务引用处（Interfaces 小节）保持一致。
+- **占位符扫描**：所有 Step 均给出完整可运行代码，无 TBD/TODO。

--- a/docs/superpowers/reviews/2026-08-31-redis-lock-limiter-pr58-review.md
+++ b/docs/superpowers/reviews/2026-08-31-redis-lock-limiter-pr58-review.md
@@ -1,0 +1,63 @@
+# Code Review Report — PR #58 (Issue #56)
+
+**分支**：`feat/56-redis-lock-limiter` → `main`
+**PR**：https://github.com/byx-darwin/go-tools/pull/58
+**日期**：2026-08-31
+
+> ⚠️ 本报告为汇总性文档，非 GitHub 正式 review。PR 作者与本次交付执行账号同为 `byx-darwin`，按 `gf-review` skill 规则禁止自我审查提交正式批准/驳回结论，需人工审查者在 GitHub 上完成正式 approve。
+
+## 交付摘要
+
+在 `go-middleware/redis` 新增：
+- `Mutex`（分布式锁）：单实例 `SET NX PX` + Lua 原子释放 + watchdog 自动续期
+- `Limiter`（限流器）：令牌桶算法，Lua 原子实现，API 对齐 `golang.org/x/time/rate.Limiter`
+- 错误码 `CodeLockAcquire=20103`、`CodeLockRelease=20104`、`CodeLimiterEval=20105`
+
+## 审查过程
+
+1. **10 个实现任务**，每个均为 TDD 循环 + 独立 task reviewer 审查，全部 Approved
+2. **1 次 Task 8 修复轮**：`ttlMillis()` 在 `rate<=0` 时溢出导致 `PEXPIRE` 报错，已修复并通过 scoped re-review
+3. **全分支最终 review**（opus 模型）：发现 5 个 Important + 9 个 Minor
+4. **1 次全分支修复轮**：一次性处理全部 5 个 Important + 1 个建议合并前处理的 Minor（选项重命名），通过 scoped re-review 确认全部解决
+
+## 已解决的 Important 问题
+
+| # | 问题 | 修复 |
+|---|------|------|
+| 1 | `AllowN` 传入负数 `n` 可静默突破限流语义 | Go 侧 `n<=0` 直接放行 + Lua 侧 `hmset` 前 clamp `min(burst, tokens)` |
+| 2 | `Limiter.Wait` 与 `Mutex.Lock` 对 ctx 取消的错误返回形态不一致 | `Wait` 改为 `ErrLimiterEval.Wrap(ctx.Err())`，与 `Lock` 一致，`errors.Is` 仍可穿透 |
+| 3 | 锁丢失（watchdog 续期失败）对调用方完全不可观测 | 已在 godoc 中显式声明该局限（未新增 API，避免范围蔓延） |
+| 4 | 设计文档承诺的 godoc 用法示例缺失 | 已为 `Mutex`/`Limiter` 补充用法示例 |
+| 5 | `NewLimiter` 不校验负数 `r`/`burst`，且 `rate=0` 会因 1s TTL 兜底被静默重置为"每秒放行" | clamp 负数为 0；`rate<=0` 时 TTL 兜底改为 24h |
+
+## 已解决的 Minor（合并前处理）
+
+- `WithTTL`/`WithRetryInterval` 重命名为 `WithMutexTTL`/`WithMutexRetryInterval`，避免与未来 `LimiterOption`/`ClientOption` 命名空间冲突（发布前零成本，发布后是破坏性变更）
+
+## 已记录但延后处理的 Minor（不阻塞合并）
+
+1. Redis 传输错误与"锁竞争/未持有"共用 `CodeLockAcquire`/`CodeLockRelease`（→409），实际应为 503，与 `CodeConnect` 一致
+2. `Unlock` 的 `res==0` 分支未清空 `m.token`（无害，token 全局唯一）
+3. 重复 `TryLock`（在 `ErrLockRelease` 后）可能遗留一个有界存活的旧 watchdog goroutine
+4. watchdog 续期调用使用 `context.Background()` 无超时，依赖 go-redis 默认 `ReadTimeout`
+5. `AllowN` 的 `now` 由客户端传入，多节点时钟不同步会导致限流临时收紧（fail-closed 方向，非正确性问题）
+6. `hmset` 已弃用，建议改用 `HSET`
+7. `renewScript` 缺少 godoc（unexported，仅风格一致性问题）
+8. 两处测试覆盖粒度问题：`TestLimiter_Refill_OverTime` 未单独断言 burst 上限；`TestMutex_Watchdog_StopsAfterUnlock` 无法区分真实实现与空实现
+
+## 测试验证
+
+```
+go build ./go-common/... ./go-auth/... ./go-middleware/... ./go-framework/...   ✅
+go vet 同上                                                                      ✅
+go test ./go-common/... ./go-auth/... ./go-middleware/... ./go-framework/... \
+  -count=1 -race                                                                ✅ 全部通过
+gofmt -l                                                                        ✅ 无输出
+golangci-lint v2                                                                ⚠️ 本地环境不可用（v1.64.8 vs 仓库要求 v2，既有环境问题），需 CI 验证
+```
+
+## 结论
+
+**技术评估**：核心分布式原语实现正确（Lua 原子性、token 校验、Unlock/watchdog 时序、`crypto/rand` 使用），经过充分的多轮审查与修复，无 Critical 缺陷，所有 Important 问题均已解决。剩余 Minor 均为打磨性质，已记录供后续跟进。
+
+**建议**：Ready to merge（待人工在 GitHub 上完成正式 approve，以及 CI 上 golangci-lint v2 的最终确认）。

--- a/docs/superpowers/specs/2026-08-31-redis-lock-limiter-design.md
+++ b/docs/superpowers/specs/2026-08-31-redis-lock-limiter-design.md
@@ -1,0 +1,188 @@
+# Redis 分布式锁与限流器封装 — 设计文档
+
+- Issue: [#56](https://github.com/byx-darwin/go-tools/issues/56)
+- 模块：`go-middleware/redis`
+- 日期：2026-08-31
+
+## 背景
+
+`go-middleware/redis` 目前只提供裸的 `redis.UniversalClient` 连接层封装（`NewUniversalClient`/`NewClient`，支持单节点/哨兵/集群、TLS、OTel 追踪）。作为微服务脚手架的中间件基础库，缺少两类最常见的业务级用法封装：分布式锁、限流器。业务项目各自实现容易出现不一致甚至有 bug 的版本（锁的可重入性/续期、限流的原子性都需要 Lua 脚本或恰当的 Redis 命令组合）。
+
+## 目标
+
+在 `go-middleware/redis` 包内新增分布式锁（`Mutex`）和限流器（`Limiter`）封装，作为基于 `redis.UniversalClient` 的上层工具。
+
+## 分布式锁（Mutex）
+
+**文件**：`go-middleware/redis/lock.go`
+
+### 选型结论
+
+- **单实例 `SET NX PX` + Lua 释放脚本**，不做 Redlock（多实例）。理由：Redlock 的正确性在社区一直有争议（Martin Kleppmann 的批评），微服务场景下单实例锁配合哨兵/集群的高可用已经足够，多实例方案的实现复杂度和运维成本收益有限。
+- **需要 watchdog 续期**：后台 goroutine 按 `ttl/3` 周期执行 Lua 续期脚本（校验持有者 token 后 `PEXPIRE`），防止业务处理时间超过锁 TTL 导致锁提前释放。`Unlock` 或 `ctx` 取消时停止续期。
+- **API 形态**：返回 `Mutex` 对象（`Lock`/`TryLock`/`Unlock`），不提供函数式 `WithLock` 包装（YAGNI，调用方可自行用 `defer` 包装）。
+
+### 结构
+
+```go
+// Mutex 基于 Redis 的分布式互斥锁，不支持可重入。
+type Mutex struct {
+    client        redis.UniversalClient
+    key           string
+    ttl           time.Duration
+    retryInterval time.Duration
+    watchdog      bool
+
+    mu     sync.Mutex // 保护 token/stopCh 等内部可变状态
+    token  string     // 每次 Lock 成功后生成的随机持有者标识
+    stopCh chan struct{}
+}
+
+// MutexOption 定义 Mutex 创建选项。
+type MutexOption func(*mutexOptions)
+
+// NewMutex 创建分布式锁实例。
+// 默认配置：ttl=10s，retryInterval=100ms，watchdog=true。
+func NewMutex(client redis.UniversalClient, key string, opts ...MutexOption) *Mutex
+
+// WithTTL 设置锁的过期时间（必须 > 0）。
+func WithTTL(ttl time.Duration) MutexOption
+
+// WithRetryInterval 设置 Lock 阻塞重试的轮询间隔（必须 > 0）。
+func WithRetryInterval(interval time.Duration) MutexOption
+
+// WithWatchdog 设置是否启用续期 watchdog（默认 true）。
+func WithWatchdog(enabled bool) MutexOption
+
+// Lock 阻塞获取锁，直到成功或 ctx 取消。成功后自动启动 watchdog（若启用）。
+func (m *Mutex) Lock(ctx context.Context) error
+
+// TryLock 单次非阻塞尝试获取锁。
+func (m *Mutex) TryLock(ctx context.Context) (bool, error)
+
+// Unlock 释放锁：停止 watchdog，Lua 脚本校验 token 匹配后删除 key。
+// 若锁已过期或被其他持有者持有，返回 ErrLockRelease。
+func (m *Mutex) Unlock(ctx context.Context) error
+```
+
+### 机制细节
+
+- **加锁**：`SET key token NX PX <ttl_ms>`；`token` 用 `crypto/rand` 生成随机字符串（每次 `Lock`/`TryLock` 成功时重新生成）。
+- **释放**（Lua，原子）：
+  ```lua
+  if redis.call('get', KEYS[1]) == ARGV[1] then
+      return redis.call('del', KEYS[1])
+  else
+      return 0
+  end
+  ```
+  返回 0 表示未持有或已过期，映射为 `ErrLockRelease`。
+- **续期**（Lua，原子，watchdog goroutine 周期调用）：
+  ```lua
+  if redis.call('get', KEYS[1]) == ARGV[1] then
+      return redis.call('pexpire', KEYS[1], ARGV[2])
+  else
+      return 0
+  end
+  ```
+  续期失败（返回 0，说明锁已丢失）时 watchdog 自行退出，不重试。
+- **`Lock` 重试**：轮询 `TryLock`，按 `retryInterval` 间隔重试，直到成功或 `ctx.Done()`。
+- 不支持可重入：一个 `Mutex` 实例代表一次加锁会话，重复调用 `Lock` 前需先 `Unlock`。
+
+## 限流器（Limiter）
+
+**文件**：`go-middleware/redis/limiter.go`
+
+### 选型结论
+
+- **令牌桶算法**，不做滑动窗口。理由：令牌桶允许突发流量（burst）且平滑限制平均速率，实现开销（Redis Hash 存两个字段）远低于滑动窗口（每请求一条记录），且语义与 Go 标准库 `golang.org/x/time/rate` 一致，便于业务从本地限流器迁移到分布式限流器。
+- **API 对齐 `golang.org/x/time/rate.Limiter`** 的方法命名（`Allow`/`AllowN`/`Wait`），但因跨网络调用 Redis，签名带 `ctx` 且返回 `error`（本地版本没有）。
+
+### 结构
+
+```go
+// Limiter 基于 Redis 的分布式令牌桶限流器。
+type Limiter struct {
+    client           redis.UniversalClient
+    key              string
+    rate             float64 // 每秒生成令牌数
+    burst            int     // 桶容量
+    waitPollInterval time.Duration
+}
+
+// LimiterOption 定义 Limiter 创建选项。
+type LimiterOption func(*limiterOptions)
+
+// NewLimiter 创建分布式限流器。r 为每秒生成令牌数，burst 为桶容量。
+// 默认配置：waitPollInterval=50ms。
+func NewLimiter(client redis.UniversalClient, key string, r float64, burst int, opts ...LimiterOption) *Limiter
+
+// WithWaitPollInterval 设置 Wait 轮询重试间隔（必须 > 0）。
+func WithWaitPollInterval(interval time.Duration) LimiterOption
+
+// Allow 等价于 AllowN(ctx, 1)。
+func (l *Limiter) Allow(ctx context.Context) (bool, error)
+
+// AllowN 尝试消耗 n 个令牌，返回是否成功。
+func (l *Limiter) AllowN(ctx context.Context, n int) (bool, error)
+
+// Wait 阻塞直到成功获取 1 个令牌或 ctx 取消/超时。
+func (l *Limiter) Wait(ctx context.Context) error
+```
+
+### 机制细节
+
+- **状态存储**：Redis Hash（`key`）存 `tokens`（当前令牌数）、`last_refill_ts`（毫秒时间戳）。
+- **Lua 脚本**（原子）：
+  1. 读取 `tokens`/`last_refill_ts`，若不存在则初始化为 `tokens=burst, last_refill_ts=now`
+  2. `elapsed = now - last_refill_ts`；`refill = elapsed/1000 * rate`；`tokens = min(burst, tokens + refill)`
+  3. 若 `tokens >= n`：`tokens -= n`，写回并 `PEXPIRE key <ttl>`，返回 1（成功）
+  4. 否则：写回补充后的 `tokens`（不写回则下次计算 elapsed 会重复补充，需持久化），`PEXPIRE`，返回 0（失败）
+- **Key TTL**：每次调用后设置为 `2 * (burst / rate) * 1000` 毫秒（向上取整，至少 1s），避免闲置 key 常驻内存。
+- **`Wait`**：内部循环调用 `AllowN(ctx, 1)`，失败则 `time.Sleep(waitPollInterval)`（响应 `ctx.Done()`），直到成功或 ctx 取消返回其错误。
+
+## 错误码
+
+延续 `go-middleware/redis/errors.go` 现有编号（20101-20102 已用于连接/埋点），新增：
+
+```go
+const (
+    CodeLockAcquire = 20103 // 加锁失败（Lock 因 ctx 取消退出）
+    CodeLockRelease = 20104 // Unlock 时未持有锁（token 不匹配/已过期）或 Redis 操作失败
+    CodeLimiterEval = 20105 // 限流器 Lua 脚本执行失败
+)
+
+var (
+    ErrLockAcquire = goerror.Code(CodeLockAcquire).Public("redis_lock_acquire_error")
+    ErrLockRelease = goerror.Code(CodeLockRelease).Public("redis_lock_release_error")
+    ErrLimiterEval = goerror.Code(CodeLimiterEval).Public("redis_limiter_eval_error")
+)
+```
+
+HTTP 状态码映射沿用 `init()` 中 `RegisterHTTPStatuses` 模式（503/500，与现有 `CodeConnect`/`CodeInstrument` 一致的量级）。
+
+## 测试
+
+`go-middleware/redis/lock_test.go`、`go-middleware/redis/limiter_test.go`，复用 `go-middleware/auth` 的 `miniredis.RunT` 测试模式：
+
+**Mutex**
+- `TryLock`/`Lock` 单实例加锁成功、`Unlock` 成功释放
+- 并发竞争：两个 `Mutex` 实例对同一 key，只有一方 `TryLock` 成功
+- 非持有者 `Unlock` 返回 `ErrLockRelease`
+- watchdog 续期：`miniredis.FastForward` 超过初始 TTL 后锁仍被持有（验证续期生效）；`WithWatchdog(false)` 时锁会按 TTL 过期
+- `Lock` 在锁被占用时阻塞重试，锁释放后成功获取；`ctx` 取消时 `Lock` 及时返回
+
+**Limiter**
+- `Allow`/`AllowN` 在 burst 范围内成功，超出后返回 `false`
+- `miniredis.FastForward` 模拟时间流逝后令牌按 `rate` 补充
+- `Wait` 在令牌不足时阻塞，令牌可用后返回；`ctx` 超时时返回其错误
+
+## 文档
+
+`go-middleware/redis` 目前无独立 README，用法说明以 `lock.go`/`limiter.go` 包级 godoc 注释（含用法示例）为准，风格与 `client.go` 一致。
+
+## 范围外（Out of Scope）
+
+- Redlock（多实例锁）— 已决策不做
+- 滑动窗口/固定窗口限流算法 — 已决策不做，仅实现令牌桶
+- 可重入锁语义

--- a/go-middleware/redis/errors.go
+++ b/go-middleware/redis/errors.go
@@ -4,12 +4,18 @@ import (
 	goerror "github.com/byx-darwin/go-tools/go-common/error"
 )
 
-// Redis 错误码 20101-20102。
+// Redis 错误码 20101-20105。
 const (
 	// CodeConnect Redis 连接/Ping 失败
 	CodeConnect = 20101
 	// CodeInstrument Redis OpenTelemetry 埋点初始化失败
 	CodeInstrument = 20102
+	// CodeLockAcquire 分布式锁加锁失败
+	CodeLockAcquire = 20103
+	// CodeLockRelease 分布式锁释放失败（未持有或已过期）
+	CodeLockRelease = 20104
+	// CodeLimiterEval 限流器 Lua 脚本执行失败
+	CodeLimiterEval = 20105
 )
 
 // 预定义 Redis 错误构造器。
@@ -18,12 +24,21 @@ var (
 	ErrConnect = goerror.Code(CodeConnect).Public("redis_connect_error")
 	// ErrInstrument Redis OpenTelemetry 埋点初始化失败
 	ErrInstrument = goerror.Code(CodeInstrument).Public("redis_instrument_error")
+	// ErrLockAcquire 分布式锁加锁失败
+	ErrLockAcquire = goerror.Code(CodeLockAcquire).Public("redis_lock_acquire_error")
+	// ErrLockRelease 分布式锁释放失败
+	ErrLockRelease = goerror.Code(CodeLockRelease).Public("redis_lock_release_error")
+	// ErrLimiterEval 限流器 Lua 脚本执行失败
+	ErrLimiterEval = goerror.Code(CodeLimiterEval).Public("redis_limiter_eval_error")
 )
 
 // init 注册 Redis 错误码的细粒度 HTTP 状态码映射。
 func init() {
 	goerror.RegisterHTTPStatuses(map[int]int{
-		CodeConnect:    503,
-		CodeInstrument: 500,
+		CodeConnect:     503,
+		CodeInstrument:  500,
+		CodeLockAcquire: 409,
+		CodeLockRelease: 409,
+		CodeLimiterEval: 500,
 	})
 }

--- a/go-middleware/redis/errors_test.go
+++ b/go-middleware/redis/errors_test.go
@@ -31,3 +31,32 @@ func TestHTTPStatusRegistration(t *testing.T) {
 	assert.Equal(t, 503, goerror.HTTPStatus(redis.ErrConnect.Wrap(errors.New("x"))))
 	assert.Equal(t, 500, goerror.HTTPStatus(redis.ErrInstrument.Wrap(errors.New("x"))))
 }
+
+// TestLockLimiterCodeValues 码值是 wire 契约，逐值锁定。
+func TestLockLimiterCodeValues(t *testing.T) {
+	assert.Equal(t, 20103, redis.CodeLockAcquire)
+	assert.Equal(t, 20104, redis.CodeLockRelease)
+	assert.Equal(t, 20105, redis.CodeLimiterEval)
+}
+
+// TestLockLimiterPredefinedErrors 构造器 code + public 消息符合预期。
+func TestLockLimiterPredefinedErrors(t *testing.T) {
+	code, public := goerror.Extract(redis.ErrLockAcquire.Wrap(errors.New("x")))
+	assert.Equal(t, 20103, code)
+	assert.Equal(t, "redis_lock_acquire_error", public)
+
+	code, public = goerror.Extract(redis.ErrLockRelease.Wrap(errors.New("x")))
+	assert.Equal(t, 20104, code)
+	assert.Equal(t, "redis_lock_release_error", public)
+
+	code, public = goerror.Extract(redis.ErrLimiterEval.Wrap(errors.New("x")))
+	assert.Equal(t, 20105, code)
+	assert.Equal(t, "redis_limiter_eval_error", public)
+}
+
+// TestLockLimiterHTTPStatusRegistration init() 注册的 HTTP 状态映射。
+func TestLockLimiterHTTPStatusRegistration(t *testing.T) {
+	assert.Equal(t, 409, goerror.HTTPStatus(redis.ErrLockAcquire.Wrap(errors.New("x"))))
+	assert.Equal(t, 409, goerror.HTTPStatus(redis.ErrLockRelease.Wrap(errors.New("x"))))
+	assert.Equal(t, 500, goerror.HTTPStatus(redis.ErrLimiterEval.Wrap(errors.New("x"))))
+}

--- a/go-middleware/redis/limiter.go
+++ b/go-middleware/redis/limiter.go
@@ -103,8 +103,12 @@ func (l *Limiter) AllowN(ctx context.Context, n int) (bool, error) {
 }
 
 // ttlMillis 计算 bucket key 的过期时间（约为完全补满所需时间的 2 倍，至少 1 秒），
-// 避免闲置 key 常驻内存。
+// 避免闲置 key 常驻内存。rate <= 0 时无法计算有意义的补满时间，回退到 1 秒下限，
+// 避免除以零导致 +Inf/NaN 进而使 PEXPIRE 溢出或清空 key。
 func (l *Limiter) ttlMillis() int64 {
+	if l.rate <= 0 {
+		return 1000
+	}
 	seconds := 2 * (float64(l.burst) / l.rate)
 	if seconds < 1 {
 		seconds = 1

--- a/go-middleware/redis/limiter.go
+++ b/go-middleware/redis/limiter.go
@@ -1,0 +1,52 @@
+package redis
+
+import (
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+)
+
+const defaultWaitPollInterval = 50 * time.Millisecond
+
+// Limiter 基于 Redis 的分布式令牌桶限流器。
+// 方法命名对齐 golang.org/x/time/rate.Limiter（Allow/AllowN/Wait），
+// 但因跨网络调用 Redis，签名带 ctx 且返回 error。
+type Limiter struct {
+	client           goredis.UniversalClient
+	key              string
+	rate             float64
+	burst            int
+	waitPollInterval time.Duration
+}
+
+// LimiterOption 定义 Limiter 创建选项。
+type LimiterOption func(*limiterOptions)
+
+type limiterOptions struct {
+	waitPollInterval time.Duration
+}
+
+// WithWaitPollInterval 设置 Wait 轮询重试间隔（必须 > 0，否则忽略）。
+func WithWaitPollInterval(interval time.Duration) LimiterOption {
+	return func(o *limiterOptions) {
+		if interval > 0 {
+			o.waitPollInterval = interval
+		}
+	}
+}
+
+// NewLimiter 创建分布式限流器。r 为每秒生成令牌数，burst 为桶容量。
+// 默认配置：waitPollInterval=50ms。
+func NewLimiter(client goredis.UniversalClient, key string, r float64, burst int, opts ...LimiterOption) *Limiter {
+	o := &limiterOptions{waitPollInterval: defaultWaitPollInterval}
+	for _, opt := range opts {
+		opt(o)
+	}
+	return &Limiter{
+		client:           client,
+		key:              key,
+		rate:             r,
+		burst:            burst,
+		waitPollInterval: o.waitPollInterval,
+	}
+}

--- a/go-middleware/redis/limiter.go
+++ b/go-middleware/redis/limiter.go
@@ -102,6 +102,25 @@ func (l *Limiter) AllowN(ctx context.Context, n int) (bool, error) {
 	return res == 1, nil
 }
 
+// Wait 阻塞直到成功获取 1 个令牌，或 ctx 取消/超时返回其错误。
+func (l *Limiter) Wait(ctx context.Context) error {
+	for {
+		ok, err := l.Allow(ctx)
+		if err != nil {
+			return err
+		}
+		if ok {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(l.waitPollInterval):
+		}
+	}
+}
+
 // ttlMillis 计算 bucket key 的过期时间（约为完全补满所需时间的 2 倍，至少 1 秒），
 // 避免闲置 key 常驻内存。rate <= 0 时无法计算有意义的补满时间，回退到 1 秒下限，
 // 避免除以零导致 +Inf/NaN 进而使 PEXPIRE 溢出或清空 key。

--- a/go-middleware/redis/limiter.go
+++ b/go-middleware/redis/limiter.go
@@ -12,6 +12,24 @@ const defaultWaitPollInterval = 50 * time.Millisecond
 // Limiter 基于 Redis 的分布式令牌桶限流器。
 // 方法命名对齐 golang.org/x/time/rate.Limiter（Allow/AllowN/Wait），
 // 但因跨网络调用 Redis，签名带 ctx 且返回 error。
+//
+// 用法示例：
+//
+//	l := redis.NewLimiter(client, "limiter:api:user123", 10, 20) // 10 tokens/s, burst=20
+//
+//	// 非阻塞检查：
+//	ok, err := l.Allow(ctx)
+//	if err != nil {
+//		return err
+//	}
+//	if !ok {
+//		return errTooManyRequests
+//	}
+//
+//	// 阻塞直到有令牌可用（或 ctx 取消）：
+//	if err := l.Wait(ctx); err != nil {
+//		return err
+//	}
 type Limiter struct {
 	client           goredis.UniversalClient
 	key              string
@@ -37,11 +55,18 @@ func WithWaitPollInterval(interval time.Duration) LimiterOption {
 }
 
 // NewLimiter 创建分布式限流器。r 为每秒生成令牌数，burst 为桶容量。
+// r、burst 若为负数会被钳制为 0（rate=0 表示永不补充令牌，burst=0 表示每次请求都拒绝）。
 // 默认配置：waitPollInterval=50ms。
 func NewLimiter(client goredis.UniversalClient, key string, r float64, burst int, opts ...LimiterOption) *Limiter {
 	o := &limiterOptions{waitPollInterval: defaultWaitPollInterval}
 	for _, opt := range opts {
 		opt(o)
+	}
+	if r < 0 {
+		r = 0
+	}
+	if burst < 0 {
+		burst = 0
 	}
 	return &Limiter{
 		client:           client,
@@ -54,6 +79,8 @@ func NewLimiter(client goredis.UniversalClient, key string, r float64, burst int
 
 // tokenBucketScript 原子化令牌桶脚本：按 elapsed 时间补充令牌（上限 burst），
 // 若余量 >= requested 则扣减并放行，否则拒绝；同时刷新 key 的过期时间。
+// requested 理论上应恒为正（Go 层 AllowN 已拦截 n<=0），此处的 math.min(burst, tokens)
+// 钳制是纵深防御：即便脚本被绕过 Go 层以负数 requested 调用，扣减后也不会残留超过 burst 的余量。
 var tokenBucketScript = goredis.NewScript(`
 local tokens_key = KEYS[1]
 local rate = tonumber(ARGV[1])
@@ -80,6 +107,7 @@ if tokens >= requested then
 	tokens = tokens - requested
 	allowed = 1
 end
+tokens = math.min(burst, tokens)
 
 redis.call('hmset', tokens_key, 'tokens', tokens, 'last_refill_ts', now)
 redis.call('pexpire', tokens_key, ttl)
@@ -93,7 +121,12 @@ func (l *Limiter) Allow(ctx context.Context) (bool, error) {
 }
 
 // AllowN 尝试消耗 n 个令牌，返回是否成功。
+// n<=0 时直接返回 (true, nil) 且不访问 Redis，对齐 golang.org/x/time/rate.Limiter
+// 对非正 n 的宽松处理；这也避免了负数 n 让令牌桶余量在 Lua 脚本中被误加而超过 burst 的问题。
 func (l *Limiter) AllowN(ctx context.Context, n int) (bool, error) {
+	if n <= 0 {
+		return true, nil
+	}
 	now := time.Now().UnixMilli()
 	res, err := tokenBucketScript.Run(ctx, l.client, []string{l.key}, l.rate, l.burst, now, n, l.ttlMillis()).Int64()
 	if err != nil {
@@ -103,6 +136,10 @@ func (l *Limiter) AllowN(ctx context.Context, n int) (bool, error) {
 }
 
 // Wait 阻塞直到成功获取 1 个令牌，或 ctx 取消/超时返回其错误。
+//
+// ctx 取消时返回 ErrLimiterEval.Wrap(ctx.Err())（与 Mutex.Lock 保持一致的错误分类，
+// 复用 code 20105，不新增错误码）：errors.Is(err, context.DeadlineExceeded) 或
+// errors.Is(err, context.Canceled) 仍可通过该 wrap 链正常工作。
 func (l *Limiter) Wait(ctx context.Context) error {
 	for {
 		ok, err := l.Allow(ctx)
@@ -115,18 +152,19 @@ func (l *Limiter) Wait(ctx context.Context) error {
 
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return ErrLimiterEval.Wrap(ctx.Err())
 		case <-time.After(l.waitPollInterval):
 		}
 	}
 }
 
 // ttlMillis 计算 bucket key 的过期时间（约为完全补满所需时间的 2 倍，至少 1 秒），
-// 避免闲置 key 常驻内存。rate <= 0 时无法计算有意义的补满时间，回退到 1 秒下限，
-// 避免除以零导致 +Inf/NaN 进而使 PEXPIRE 溢出或清空 key。
+// 避免闲置 key 常驻内存。rate <= 0 时无法计算有意义的补满时间（且理论上永不需要重新
+// 补满），回退到 24 小时的下限：既避免除以零导致 +Inf/NaN 进而使 PEXPIRE 溢出或清空 key，
+// 又避免像 1 秒下限那样在正常调用间隔内就把 key 的已耗尽状态错误地重置为满桶。
 func (l *Limiter) ttlMillis() int64 {
 	if l.rate <= 0 {
-		return 1000
+		return 24 * 60 * 60 * 1000
 	}
 	seconds := 2 * (float64(l.burst) / l.rate)
 	if seconds < 1 {

--- a/go-middleware/redis/limiter.go
+++ b/go-middleware/redis/limiter.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"context"
 	"time"
 
 	goredis "github.com/redis/go-redis/v9"
@@ -49,4 +50,64 @@ func NewLimiter(client goredis.UniversalClient, key string, r float64, burst int
 		burst:            burst,
 		waitPollInterval: o.waitPollInterval,
 	}
+}
+
+// tokenBucketScript 原子化令牌桶脚本：按 elapsed 时间补充令牌（上限 burst），
+// 若余量 >= requested 则扣减并放行，否则拒绝；同时刷新 key 的过期时间。
+var tokenBucketScript = goredis.NewScript(`
+local tokens_key = KEYS[1]
+local rate = tonumber(ARGV[1])
+local burst = tonumber(ARGV[2])
+local now = tonumber(ARGV[3])
+local requested = tonumber(ARGV[4])
+local ttl = tonumber(ARGV[5])
+
+local data = redis.call('hmget', tokens_key, 'tokens', 'last_refill_ts')
+local tokens = tonumber(data[1])
+local last_refill_ts = tonumber(data[2])
+
+if tokens == nil then
+	tokens = burst
+	last_refill_ts = now
+end
+
+local elapsed = math.max(0, now - last_refill_ts)
+local refill = (elapsed / 1000) * rate
+tokens = math.min(burst, tokens + refill)
+
+local allowed = 0
+if tokens >= requested then
+	tokens = tokens - requested
+	allowed = 1
+end
+
+redis.call('hmset', tokens_key, 'tokens', tokens, 'last_refill_ts', now)
+redis.call('pexpire', tokens_key, ttl)
+
+return allowed
+`)
+
+// Allow 等价于 AllowN(ctx, 1)。
+func (l *Limiter) Allow(ctx context.Context) (bool, error) {
+	return l.AllowN(ctx, 1)
+}
+
+// AllowN 尝试消耗 n 个令牌，返回是否成功。
+func (l *Limiter) AllowN(ctx context.Context, n int) (bool, error) {
+	now := time.Now().UnixMilli()
+	res, err := tokenBucketScript.Run(ctx, l.client, []string{l.key}, l.rate, l.burst, now, n, l.ttlMillis()).Int64()
+	if err != nil {
+		return false, ErrLimiterEval.Wrap(err)
+	}
+	return res == 1, nil
+}
+
+// ttlMillis 计算 bucket key 的过期时间（约为完全补满所需时间的 2 倍，至少 1 秒），
+// 避免闲置 key 常驻内存。
+func (l *Limiter) ttlMillis() int64 {
+	seconds := 2 * (float64(l.burst) / l.rate)
+	if seconds < 1 {
+		seconds = 1
+	}
+	return int64(seconds * 1000)
 }

--- a/go-middleware/redis/limiter_test.go
+++ b/go-middleware/redis/limiter_test.go
@@ -20,6 +20,19 @@ func TestNewLimiter_Defaults(t *testing.T) {
 	assert.Equal(t, defaultWaitPollInterval, l.waitPollInterval)
 }
 
+func TestNewLimiter_ClampsNegativeParams(t *testing.T) {
+	_, client := newTestRedisClient(t)
+
+	l := NewLimiter(client, "limiter:negative", -1, -1)
+
+	assert.InDelta(t, 0.0, l.rate, 0.0001)
+	assert.Equal(t, 0, l.burst)
+
+	ok, err := l.Allow(context.Background())
+	require.NoError(t, err)
+	assert.False(t, ok, "burst=0 after clamping negative input must reject immediately")
+}
+
 func TestNewLimiter_CustomOptions(t *testing.T) {
 	_, client := newTestRedisClient(t)
 
@@ -64,6 +77,32 @@ func TestLimiter_AllowN_RejectsWhenInsufficientTokens(t *testing.T) {
 	ok, err = l.AllowN(ctx, 3)
 	require.NoError(t, err)
 	assert.False(t, ok, "only 2 tokens remain, requesting 3 must fail")
+}
+
+func TestLimiter_AllowN_NonPositiveN(t *testing.T) {
+	_, client := newTestRedisClient(t)
+	ctx := context.Background()
+	l := NewLimiter(client, "limiter:nonpositive", 1, 1)
+
+	// Exhaust the single token so a naive implementation (tokens >= n with
+	// n<=0) would otherwise inflate the bucket instead of short-circuiting.
+	ok, err := l.Allow(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	ok, err = l.AllowN(ctx, 0)
+	require.NoError(t, err)
+	assert.True(t, ok, "n=0 must be permissively allowed without touching the bucket")
+
+	ok, err = l.AllowN(ctx, -5)
+	require.NoError(t, err)
+	assert.True(t, ok, "negative n must be permissively allowed without touching the bucket")
+
+	// Bucket must still be exhausted for positive n — negative n must not
+	// have inflated the stored token count above burst.
+	ok, err = l.Allow(ctx)
+	require.NoError(t, err)
+	assert.False(t, ok, "bucket must remain exhausted after non-positive AllowN calls")
 }
 
 func TestLimiter_Refill_OverTime(t *testing.T) {

--- a/go-middleware/redis/limiter_test.go
+++ b/go-middleware/redis/limiter_test.go
@@ -1,0 +1,35 @@
+package redis
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewLimiter_Defaults(t *testing.T) {
+	_, client := newTestRedisClient(t)
+
+	l := NewLimiter(client, "limiter:test", 10, 5)
+
+	assert.Equal(t, "limiter:test", l.key)
+	assert.InDelta(t, 10.0, l.rate, 0.0001)
+	assert.Equal(t, 5, l.burst)
+	assert.Equal(t, defaultWaitPollInterval, l.waitPollInterval)
+}
+
+func TestNewLimiter_CustomOptions(t *testing.T) {
+	_, client := newTestRedisClient(t)
+
+	l := NewLimiter(client, "limiter:test", 10, 5, WithWaitPollInterval(200*time.Millisecond))
+
+	assert.Equal(t, 200*time.Millisecond, l.waitPollInterval)
+}
+
+func TestLimiterOption_IgnoresInvalidValues(t *testing.T) {
+	_, client := newTestRedisClient(t)
+
+	l := NewLimiter(client, "limiter:test", 10, 5, WithWaitPollInterval(0))
+
+	assert.Equal(t, defaultWaitPollInterval, l.waitPollInterval)
+}

--- a/go-middleware/redis/limiter_test.go
+++ b/go-middleware/redis/limiter_test.go
@@ -1,10 +1,12 @@
 package redis
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewLimiter_Defaults(t *testing.T) {
@@ -32,4 +34,60 @@ func TestLimiterOption_IgnoresInvalidValues(t *testing.T) {
 	l := NewLimiter(client, "limiter:test", 10, 5, WithWaitPollInterval(0))
 
 	assert.Equal(t, defaultWaitPollInterval, l.waitPollInterval)
+}
+
+func TestLimiter_AllowN_WithinBurst(t *testing.T) {
+	_, client := newTestRedisClient(t)
+	ctx := context.Background()
+	l := NewLimiter(client, "limiter:burst", 1, 3)
+
+	for i := 0; i < 3; i++ {
+		ok, err := l.Allow(ctx)
+		require.NoError(t, err)
+		assert.True(t, ok, "request %d within burst should be allowed", i)
+	}
+
+	ok, err := l.Allow(ctx)
+	require.NoError(t, err)
+	assert.False(t, ok, "request beyond burst should be rejected")
+}
+
+func TestLimiter_AllowN_RejectsWhenInsufficientTokens(t *testing.T) {
+	_, client := newTestRedisClient(t)
+	ctx := context.Background()
+	l := NewLimiter(client, "limiter:allown", 1, 5)
+
+	ok, err := l.AllowN(ctx, 3)
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	ok, err = l.AllowN(ctx, 3)
+	require.NoError(t, err)
+	assert.False(t, ok, "only 2 tokens remain, requesting 3 must fail")
+}
+
+func TestLimiter_Refill_OverTime(t *testing.T) {
+	_, client := newTestRedisClient(t)
+	ctx := context.Background()
+	l := NewLimiter(client, "limiter:refill", 10, 1) // 10 tokens/sec, burst=1
+
+	ok, err := l.Allow(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	ok, err = l.Allow(ctx)
+	require.NoError(t, err)
+	require.False(t, ok, "bucket should be empty immediately after consuming the single token")
+
+	// miniredis.FastForward only decrements existing key TTLs; it does not
+	// advance any clock the Lua script or client observes (time.Now() /
+	// redis TIME), so it cannot simulate refill here. Backdate
+	// last_refill_ts directly to deterministically simulate elapsed time:
+	// 10 tokens/sec * 0.2s = 2 tokens refilled, capped at burst=1.
+	past := time.Now().Add(-200 * time.Millisecond).UnixMilli()
+	require.NoError(t, client.HSet(ctx, "limiter:refill", "last_refill_ts", past).Err())
+
+	ok, err = l.Allow(ctx)
+	require.NoError(t, err)
+	assert.True(t, ok, "token should have refilled after 200ms at rate=10/s")
 }

--- a/go-middleware/redis/limiter_test.go
+++ b/go-middleware/redis/limiter_test.go
@@ -91,3 +91,23 @@ func TestLimiter_Refill_OverTime(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, ok, "token should have refilled after 200ms at rate=10/s")
 }
+
+func TestLimiter_AllowN_ZeroRate(t *testing.T) {
+	_, client := newTestRedisClient(t)
+	ctx := context.Background()
+	l := NewLimiter(client, "limiter:zerorate", 0, 5)
+
+	// Burst-many requests succeed from the initial token pool (never refilled
+	// since rate=0), then every subsequent request is denied. Critically,
+	// none of these calls should error: ttlMillis() must not divide by zero
+	// and produce a pathological PEXPIRE value.
+	for i := 0; i < 5; i++ {
+		ok, err := l.Allow(ctx)
+		require.NoError(t, err)
+		assert.True(t, ok, "request %d within initial burst should be allowed", i)
+	}
+
+	ok, err := l.Allow(ctx)
+	require.NoError(t, err)
+	assert.False(t, ok, "zero-rate limiter must deny once the initial burst is exhausted")
+}

--- a/go-middleware/redis/limiter_test.go
+++ b/go-middleware/redis/limiter_test.go
@@ -111,3 +111,42 @@ func TestLimiter_AllowN_ZeroRate(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, ok, "zero-rate limiter must deny once the initial burst is exhausted")
 }
+
+func TestLimiter_Wait_SucceedsAfterRefill(t *testing.T) {
+	_, client := newTestRedisClient(t)
+	ctx := context.Background()
+	l := NewLimiter(client, "limiter:wait", 100, 1, WithWaitPollInterval(5*time.Millisecond)) // fast refill for test speed
+
+	ok, err := l.Allow(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	waitCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer cancel()
+
+	err = l.Wait(waitCtx)
+
+	assert.NoError(t, err, "Wait should succeed once tokens refill at rate=100/s")
+}
+
+func TestLimiter_Wait_ContextTimeout(t *testing.T) {
+	_, client := newTestRedisClient(t)
+	ctx := context.Background()
+	// rate=0: refill is always exactly 0 regardless of elapsed time, so tokens
+	// never leave the hash in scientific-notation form (e.g. "7e-06"), which
+	// miniredis's embedded Lua interpreter fails to parse back via tonumber()
+	// for integer-mantissa exponents — that parser gap would otherwise reset
+	// the bucket to full and make Wait spuriously succeed.
+	l := NewLimiter(client, "limiter:wait-timeout", 0, 1, WithWaitPollInterval(5*time.Millisecond)) // never refills
+
+	ok, err := l.Allow(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Millisecond)
+	defer cancel()
+
+	err = l.Wait(waitCtx)
+
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}

--- a/go-middleware/redis/lock.go
+++ b/go-middleware/redis/lock.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"sync"
 	"time"
 
@@ -118,3 +119,42 @@ func (m *Mutex) TryLock(ctx context.Context) (bool, error) {
 
 // startWatchdog 在 Task 6 中实现；此处先占位为空操作以保证 TryLock 可编译独立测试。
 func (m *Mutex) startWatchdog() {}
+
+// releaseScript 校验 KEYS[1] 的值等于 ARGV[1]（持有者 token）后再删除，避免误删他人持有的锁。
+var releaseScript = goredis.NewScript(`
+if redis.call('get', KEYS[1]) == ARGV[1] then
+	return redis.call('del', KEYS[1])
+else
+	return 0
+end
+`)
+
+// Unlock 释放锁：停止 watchdog，Lua 脚本校验 token 匹配后删除 key。
+// 若锁未持有、已过期，或被其他持有者持有，返回 ErrLockRelease。
+func (m *Mutex) Unlock(ctx context.Context) error {
+	m.stopWatchdog()
+
+	m.mu.Lock()
+	token := m.token
+	m.mu.Unlock()
+
+	if token == "" {
+		return ErrLockRelease.Wrap(errors.New("lock not held"))
+	}
+
+	res, err := releaseScript.Run(ctx, m.client, []string{m.key}, token).Int64()
+	if err != nil {
+		return ErrLockRelease.Wrap(err)
+	}
+	if res == 0 {
+		return ErrLockRelease.Wrap(errors.New("lock not held or already expired"))
+	}
+
+	m.mu.Lock()
+	m.token = ""
+	m.mu.Unlock()
+	return nil
+}
+
+// stopWatchdog 在 Task 6 中实现完整逻辑；此处先占位为空操作。
+func (m *Mutex) stopWatchdog() {}

--- a/go-middleware/redis/lock.go
+++ b/go-middleware/redis/lock.go
@@ -158,3 +158,25 @@ func (m *Mutex) Unlock(ctx context.Context) error {
 
 // stopWatchdog 在 Task 6 中实现完整逻辑；此处先占位为空操作。
 func (m *Mutex) stopWatchdog() {}
+
+// Lock 阻塞获取锁，直到成功或 ctx 取消。成功后自动启动 watchdog（若启用）。
+func (m *Mutex) Lock(ctx context.Context) error {
+	ticker := time.NewTicker(m.retryInterval)
+	defer ticker.Stop()
+
+	for {
+		ok, err := m.TryLock(ctx)
+		if err != nil {
+			return err
+		}
+		if ok {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ErrLockAcquire.Wrap(ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}

--- a/go-middleware/redis/lock.go
+++ b/go-middleware/redis/lock.go
@@ -1,0 +1,81 @@
+package redis
+
+import (
+	"sync"
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+)
+
+const (
+	defaultMutexTTL      = 10 * time.Second
+	defaultRetryInterval = 100 * time.Millisecond
+)
+
+// Mutex 基于 Redis 的分布式互斥锁（单实例 SET NX PX 方案），不支持可重入。
+// 一个 Mutex 实例代表一次加锁会话：Lock/TryLock 成功后必须调用 Unlock 才能再次加锁。
+type Mutex struct {
+	client        goredis.UniversalClient
+	key           string
+	ttl           time.Duration
+	retryInterval time.Duration
+	watchdog      bool
+
+	mu     sync.Mutex
+	token  string
+	stopCh chan struct{}
+}
+
+// MutexOption 定义 Mutex 创建选项。
+type MutexOption func(*mutexOptions)
+
+type mutexOptions struct {
+	ttl           time.Duration
+	retryInterval time.Duration
+	watchdog      bool
+}
+
+// WithTTL 设置锁的过期时间（必须 > 0，否则忽略，保留默认值）。
+func WithTTL(ttl time.Duration) MutexOption {
+	return func(o *mutexOptions) {
+		if ttl > 0 {
+			o.ttl = ttl
+		}
+	}
+}
+
+// WithRetryInterval 设置 Lock 阻塞重试的轮询间隔（必须 > 0，否则忽略）。
+func WithRetryInterval(interval time.Duration) MutexOption {
+	return func(o *mutexOptions) {
+		if interval > 0 {
+			o.retryInterval = interval
+		}
+	}
+}
+
+// WithWatchdog 设置是否启用续期 watchdog（默认 true）。
+func WithWatchdog(enabled bool) MutexOption {
+	return func(o *mutexOptions) {
+		o.watchdog = enabled
+	}
+}
+
+// NewMutex 创建分布式锁实例。
+// 默认配置：ttl=10s，retryInterval=100ms，watchdog=true。
+func NewMutex(client goredis.UniversalClient, key string, opts ...MutexOption) *Mutex {
+	o := &mutexOptions{
+		ttl:           defaultMutexTTL,
+		retryInterval: defaultRetryInterval,
+		watchdog:      true,
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+	return &Mutex{
+		client:        client,
+		key:           key,
+		ttl:           o.ttl,
+		retryInterval: o.retryInterval,
+		watchdog:      o.watchdog,
+	}
+}

--- a/go-middleware/redis/lock.go
+++ b/go-middleware/redis/lock.go
@@ -117,8 +117,51 @@ func (m *Mutex) TryLock(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
-// startWatchdog 在 Task 6 中实现；此处先占位为空操作以保证 TryLock 可编译独立测试。
-func (m *Mutex) startWatchdog() {}
+var renewScript = goredis.NewScript(`
+if redis.call('get', KEYS[1]) == ARGV[1] then
+	return redis.call('pexpire', KEYS[1], ARGV[2])
+else
+	return 0
+end
+`)
+
+// startWatchdog 启动后台续期 goroutine：按 ttl/3 周期执行 Lua 续期脚本，
+// 直到 stopWatchdog 被调用或续期失败（锁已丢失）。
+func (m *Mutex) startWatchdog() {
+	stop := make(chan struct{})
+	m.mu.Lock()
+	m.stopCh = stop
+	m.mu.Unlock()
+
+	interval := m.ttl / 3
+	if interval <= 0 {
+		interval = time.Millisecond
+	}
+
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				m.mu.Lock()
+				token := m.token
+				m.mu.Unlock()
+				if token == "" {
+					return
+				}
+
+				res, err := renewScript.Run(context.Background(), m.client, []string{m.key}, token, m.ttl.Milliseconds()).Int64()
+				if err != nil || res == 0 {
+					return
+				}
+			}
+		}
+	}()
+}
 
 // releaseScript 校验 KEYS[1] 的值等于 ARGV[1]（持有者 token）后再删除，避免误删他人持有的锁。
 var releaseScript = goredis.NewScript(`
@@ -156,8 +199,17 @@ func (m *Mutex) Unlock(ctx context.Context) error {
 	return nil
 }
 
-// stopWatchdog 在 Task 6 中实现完整逻辑；此处先占位为空操作。
-func (m *Mutex) stopWatchdog() {}
+// stopWatchdog 停止续期 goroutine（幂等，可安全重复调用）。
+func (m *Mutex) stopWatchdog() {
+	m.mu.Lock()
+	stop := m.stopCh
+	m.stopCh = nil
+	m.mu.Unlock()
+
+	if stop != nil {
+		close(stop)
+	}
+}
 
 // Lock 阻塞获取锁，直到成功或 ctx 取消。成功后自动启动 watchdog（若启用）。
 func (m *Mutex) Lock(ctx context.Context) error {

--- a/go-middleware/redis/lock.go
+++ b/go-middleware/redis/lock.go
@@ -1,6 +1,9 @@
 package redis
 
 import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"sync"
 	"time"
 
@@ -79,3 +82,39 @@ func NewMutex(client goredis.UniversalClient, key string, opts ...MutexOption) *
 		watchdog:      o.watchdog,
 	}
 }
+
+func randomToken() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// TryLock 单次非阻塞尝试获取锁。成功后若启用 watchdog 会自动启动续期。
+func (m *Mutex) TryLock(ctx context.Context) (bool, error) {
+	token, err := randomToken()
+	if err != nil {
+		return false, ErrLockAcquire.Wrap(err)
+	}
+
+	ok, err := m.client.SetNX(ctx, m.key, token, m.ttl).Result()
+	if err != nil {
+		return false, ErrLockAcquire.Wrap(err)
+	}
+	if !ok {
+		return false, nil
+	}
+
+	m.mu.Lock()
+	m.token = token
+	m.mu.Unlock()
+
+	if m.watchdog {
+		m.startWatchdog()
+	}
+	return true, nil
+}
+
+// startWatchdog 在 Task 6 中实现；此处先占位为空操作以保证 TryLock 可编译独立测试。
+func (m *Mutex) startWatchdog() {}

--- a/go-middleware/redis/lock.go
+++ b/go-middleware/redis/lock.go
@@ -18,6 +18,23 @@ const (
 
 // Mutex 基于 Redis 的分布式互斥锁（单实例 SET NX PX 方案），不支持可重入。
 // 一个 Mutex 实例代表一次加锁会话：Lock/TryLock 成功后必须调用 Unlock 才能再次加锁。
+//
+// 用法示例：
+//
+//	m := redis.NewMutex(client, "lock:order:123")
+//	if err := m.Lock(ctx); err != nil {
+//		return err
+//	}
+//	defer func() {
+//		if err := m.Unlock(ctx); err != nil {
+//			// ErrLockRelease：锁未持有 / 已过期 / 被其他持有者持有，
+//			// 通常只需记录日志，不应视为业务失败。
+//			log.Warn("unlock failed", "err", err)
+//		}
+//	}()
+//	// 临界区业务逻辑
+//
+// 关于 watchdog 续期失败的可观测性限制，见 WithWatchdog 的文档说明。
 type Mutex struct {
 	client        goredis.UniversalClient
 	key           string
@@ -39,8 +56,8 @@ type mutexOptions struct {
 	watchdog      bool
 }
 
-// WithTTL 设置锁的过期时间（必须 > 0，否则忽略，保留默认值）。
-func WithTTL(ttl time.Duration) MutexOption {
+// WithMutexTTL 设置锁的过期时间（必须 > 0，否则忽略，保留默认值）。
+func WithMutexTTL(ttl time.Duration) MutexOption {
 	return func(o *mutexOptions) {
 		if ttl > 0 {
 			o.ttl = ttl
@@ -48,8 +65,8 @@ func WithTTL(ttl time.Duration) MutexOption {
 	}
 }
 
-// WithRetryInterval 设置 Lock 阻塞重试的轮询间隔（必须 > 0，否则忽略）。
-func WithRetryInterval(interval time.Duration) MutexOption {
+// WithMutexRetryInterval 设置 Lock 阻塞重试的轮询间隔（必须 > 0，否则忽略）。
+func WithMutexRetryInterval(interval time.Duration) MutexOption {
 	return func(o *mutexOptions) {
 		if interval > 0 {
 			o.retryInterval = interval
@@ -58,6 +75,10 @@ func WithRetryInterval(interval time.Duration) MutexOption {
 }
 
 // WithWatchdog 设置是否启用续期 watchdog（默认 true）。
+//
+// 局限性：当 watchdog 续期失败时（锁已被抢占或过期），后台 goroutine 会静默退出，
+// 调用方无法在临界区内感知锁已丢失，只能在下次 Unlock 时通过 ErrLockRelease 得知。
+// 如需更强的锁丢失感知能力，需要额外的通知机制（当前版本未提供）。
 func WithWatchdog(enabled bool) MutexOption {
 	return func(o *mutexOptions) {
 		o.watchdog = enabled
@@ -212,6 +233,9 @@ func (m *Mutex) stopWatchdog() {
 }
 
 // Lock 阻塞获取锁，直到成功或 ctx 取消。成功后自动启动 watchdog（若启用）。
+//
+// ctx 取消时返回 ErrLockAcquire.Wrap(ctx.Err())：errors.Is(err, context.DeadlineExceeded)
+// 或 errors.Is(err, context.Canceled) 仍可通过该 wrap 链正常工作。
 func (m *Mutex) Lock(ctx context.Context) error {
 	ticker := time.NewTicker(m.retryInterval)
 	defer ticker.Stop()

--- a/go-middleware/redis/lock_test.go
+++ b/go-middleware/redis/lock_test.go
@@ -131,3 +131,47 @@ func TestMutex_Unlock_HeldByOther(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), exists, "owner's lock must remain untouched")
 }
+
+func TestMutex_Lock_WaitsForRelease(t *testing.T) {
+	_, client := newTestRedisClient(t)
+	ctx := context.Background()
+	holder := NewMutex(client, "lock:wait", WithWatchdog(false), WithRetryInterval(10*time.Millisecond))
+	waiter := NewMutex(client, "lock:wait", WithWatchdog(false), WithRetryInterval(10*time.Millisecond))
+
+	ok, err := holder.TryLock(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- waiter.Lock(ctx)
+	}()
+
+	time.Sleep(30 * time.Millisecond)
+	require.NoError(t, holder.Unlock(ctx))
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("waiter.Lock did not return after holder released the lock")
+	}
+}
+
+func TestMutex_Lock_ContextCanceled(t *testing.T) {
+	_, client := newTestRedisClient(t)
+	holder := NewMutex(client, "lock:cancel", WithWatchdog(false))
+	waiter := NewMutex(client, "lock:cancel", WithWatchdog(false), WithRetryInterval(10*time.Millisecond))
+
+	ok, err := holder.TryLock(context.Background())
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	err = waiter.Lock(ctx)
+
+	code, _ := goerror.Extract(err)
+	assert.Equal(t, CodeLockAcquire, code)
+}

--- a/go-middleware/redis/lock_test.go
+++ b/go-middleware/redis/lock_test.go
@@ -175,3 +175,66 @@ func TestMutex_Lock_ContextCanceled(t *testing.T) {
 	code, _ := goerror.Extract(err)
 	assert.Equal(t, CodeLockAcquire, code)
 }
+
+func TestMutex_Watchdog_RenewsBeforeExpiry(t *testing.T) {
+	mr, client := newTestRedisClient(t)
+	ctx := context.Background()
+	m := NewMutex(client, "lock:watchdog", WithTTL(90*time.Millisecond), WithWatchdog(true))
+
+	ok, err := m.TryLock(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// 90ms TTL，续期间隔 = ttl/3 = 30ms。累计推进 200ms（> 原始 TTL），
+	// 若续期生效，key 应仍然存在。
+	//
+	// NOTE: mock（miniredis）时钟与真实 watchdog ticker 使用的 wall-clock 是两条独立的时间线。
+	// 为了让 watchdog 的第一次续期（真实时间 ~30ms 触发）赶在 mock 时间到达原始 TTL（90ms）
+	// 之前发生，每次循环推进的 mock 时间必须与真实 sleep 时间保持 1:1 量级（而不是原始草稿中
+	// 4:1 的比例，那样 mock 时间会在 watchdog 第一次真实触发前就已超过 TTL，导致必然失败）。
+	// 这里改为 20 次 * 10ms，保持 ttl(90ms) > 续期间隔(30ms) > 单次粒度(10ms) 的相对顺序不变。
+	for i := 0; i < 20; i++ {
+		mr.FastForward(10 * time.Millisecond)
+		time.Sleep(10 * time.Millisecond) // 让 watchdog goroutine 有机会真实执行一次续期
+	}
+
+	exists, err := client.Exists(ctx, "lock:watchdog").Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), exists, "watchdog should have renewed the lock before its original TTL")
+
+	require.NoError(t, m.Unlock(ctx))
+}
+
+func TestMutex_Watchdog_StopsAfterUnlock(t *testing.T) {
+	mr, client := newTestRedisClient(t)
+	ctx := context.Background()
+	m := NewMutex(client, "lock:watchdog-stop", WithTTL(50*time.Millisecond), WithWatchdog(true))
+
+	ok, err := m.TryLock(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NoError(t, m.Unlock(ctx))
+
+	mr.FastForward(200 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
+
+	exists, err := client.Exists(ctx, "lock:watchdog-stop").Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), exists, "key must not be recreated after Unlock stopped the watchdog")
+}
+
+func TestMutex_Watchdog_Disabled_LockExpires(t *testing.T) {
+	mr, client := newTestRedisClient(t)
+	ctx := context.Background()
+	m := NewMutex(client, "lock:no-watchdog", WithTTL(50*time.Millisecond), WithWatchdog(false))
+
+	ok, err := m.TryLock(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	mr.FastForward(60 * time.Millisecond)
+
+	exists, err := client.Exists(ctx, "lock:no-watchdog").Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), exists)
+}

--- a/go-middleware/redis/lock_test.go
+++ b/go-middleware/redis/lock_test.go
@@ -36,8 +36,8 @@ func TestNewMutex_CustomOptions(t *testing.T) {
 	_, client := newTestRedisClient(t)
 
 	m := NewMutex(client, "lock:test",
-		WithTTL(5*time.Second),
-		WithRetryInterval(20*time.Millisecond),
+		WithMutexTTL(5*time.Second),
+		WithMutexRetryInterval(20*time.Millisecond),
 		WithWatchdog(false),
 	)
 
@@ -49,7 +49,7 @@ func TestNewMutex_CustomOptions(t *testing.T) {
 func TestMutexOption_IgnoresInvalidValues(t *testing.T) {
 	_, client := newTestRedisClient(t)
 
-	m := NewMutex(client, "lock:test", WithTTL(0), WithRetryInterval(-1))
+	m := NewMutex(client, "lock:test", WithMutexTTL(0), WithMutexRetryInterval(-1))
 
 	assert.Equal(t, defaultMutexTTL, m.ttl)
 	assert.Equal(t, defaultRetryInterval, m.retryInterval)
@@ -135,8 +135,8 @@ func TestMutex_Unlock_HeldByOther(t *testing.T) {
 func TestMutex_Lock_WaitsForRelease(t *testing.T) {
 	_, client := newTestRedisClient(t)
 	ctx := context.Background()
-	holder := NewMutex(client, "lock:wait", WithWatchdog(false), WithRetryInterval(10*time.Millisecond))
-	waiter := NewMutex(client, "lock:wait", WithWatchdog(false), WithRetryInterval(10*time.Millisecond))
+	holder := NewMutex(client, "lock:wait", WithWatchdog(false), WithMutexRetryInterval(10*time.Millisecond))
+	waiter := NewMutex(client, "lock:wait", WithWatchdog(false), WithMutexRetryInterval(10*time.Millisecond))
 
 	ok, err := holder.TryLock(ctx)
 	require.NoError(t, err)
@@ -161,7 +161,7 @@ func TestMutex_Lock_WaitsForRelease(t *testing.T) {
 func TestMutex_Lock_ContextCanceled(t *testing.T) {
 	_, client := newTestRedisClient(t)
 	holder := NewMutex(client, "lock:cancel", WithWatchdog(false))
-	waiter := NewMutex(client, "lock:cancel", WithWatchdog(false), WithRetryInterval(10*time.Millisecond))
+	waiter := NewMutex(client, "lock:cancel", WithWatchdog(false), WithMutexRetryInterval(10*time.Millisecond))
 
 	ok, err := holder.TryLock(context.Background())
 	require.NoError(t, err)
@@ -179,7 +179,7 @@ func TestMutex_Lock_ContextCanceled(t *testing.T) {
 func TestMutex_Watchdog_RenewsBeforeExpiry(t *testing.T) {
 	mr, client := newTestRedisClient(t)
 	ctx := context.Background()
-	m := NewMutex(client, "lock:watchdog", WithTTL(90*time.Millisecond), WithWatchdog(true))
+	m := NewMutex(client, "lock:watchdog", WithMutexTTL(90*time.Millisecond), WithWatchdog(true))
 
 	ok, err := m.TryLock(ctx)
 	require.NoError(t, err)
@@ -208,7 +208,7 @@ func TestMutex_Watchdog_RenewsBeforeExpiry(t *testing.T) {
 func TestMutex_Watchdog_StopsAfterUnlock(t *testing.T) {
 	mr, client := newTestRedisClient(t)
 	ctx := context.Background()
-	m := NewMutex(client, "lock:watchdog-stop", WithTTL(50*time.Millisecond), WithWatchdog(true))
+	m := NewMutex(client, "lock:watchdog-stop", WithMutexTTL(50*time.Millisecond), WithWatchdog(true))
 
 	ok, err := m.TryLock(ctx)
 	require.NoError(t, err)
@@ -226,7 +226,7 @@ func TestMutex_Watchdog_StopsAfterUnlock(t *testing.T) {
 func TestMutex_Watchdog_Disabled_LockExpires(t *testing.T) {
 	mr, client := newTestRedisClient(t)
 	ctx := context.Background()
-	m := NewMutex(client, "lock:no-watchdog", WithTTL(50*time.Millisecond), WithWatchdog(false))
+	m := NewMutex(client, "lock:no-watchdog", WithMutexTTL(50*time.Millisecond), WithWatchdog(false))
 
 	ok, err := m.TryLock(ctx)
 	require.NoError(t, err)

--- a/go-middleware/redis/lock_test.go
+++ b/go-middleware/redis/lock_test.go
@@ -9,6 +9,8 @@ import (
 	goredis "github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	goerror "github.com/byx-darwin/go-tools/go-common/error"
 )
 
 func newTestRedisClient(t *testing.T) (*miniredis.Miniredis, goredis.UniversalClient) {
@@ -77,4 +79,55 @@ func TestMutex_TryLock_AlreadyHeld(t *testing.T) {
 
 	assert.NoError(t, err2)
 	assert.False(t, ok2)
+}
+
+func TestMutex_Unlock_Success(t *testing.T) {
+	_, client := newTestRedisClient(t)
+	m := NewMutex(client, "lock:unlock", WithWatchdog(false))
+	ctx := context.Background()
+
+	ok, err := m.TryLock(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	err = m.Unlock(ctx)
+
+	assert.NoError(t, err)
+
+	exists, err := client.Exists(ctx, "lock:unlock").Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), exists)
+}
+
+func TestMutex_Unlock_NotHeld(t *testing.T) {
+	_, client := newTestRedisClient(t)
+	m := NewMutex(client, "lock:notheld", WithWatchdog(false))
+
+	err := m.Unlock(context.Background())
+
+	code, _ := goerror.Extract(err)
+	assert.Equal(t, CodeLockRelease, code)
+}
+
+func TestMutex_Unlock_HeldByOther(t *testing.T) {
+	_, client := newTestRedisClient(t)
+	owner := NewMutex(client, "lock:other", WithWatchdog(false))
+	intruder := NewMutex(client, "lock:other", WithWatchdog(false))
+	ctx := context.Background()
+
+	ok, err := owner.TryLock(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	intruder.mu.Lock()
+	intruder.token = "not-the-real-token"
+	intruder.mu.Unlock()
+
+	err = intruder.Unlock(ctx)
+
+	code, _ := goerror.Extract(err)
+	assert.Equal(t, CodeLockRelease, code)
+
+	exists, err := client.Exists(ctx, "lock:other").Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), exists, "owner's lock must remain untouched")
 }

--- a/go-middleware/redis/lock_test.go
+++ b/go-middleware/redis/lock_test.go
@@ -1,12 +1,14 @@
 package redis
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
 	goredis "github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func newTestRedisClient(t *testing.T) (*miniredis.Miniredis, goredis.UniversalClient) {
@@ -49,4 +51,30 @@ func TestMutexOption_IgnoresInvalidValues(t *testing.T) {
 
 	assert.Equal(t, defaultMutexTTL, m.ttl)
 	assert.Equal(t, defaultRetryInterval, m.retryInterval)
+}
+
+func TestMutex_TryLock_Success(t *testing.T) {
+	_, client := newTestRedisClient(t)
+	m := NewMutex(client, "lock:trylock", WithWatchdog(false))
+
+	ok, err := m.TryLock(context.Background())
+
+	assert.NoError(t, err)
+	assert.True(t, ok)
+	assert.NotEmpty(t, m.token)
+}
+
+func TestMutex_TryLock_AlreadyHeld(t *testing.T) {
+	_, client := newTestRedisClient(t)
+	first := NewMutex(client, "lock:contested", WithWatchdog(false))
+	second := NewMutex(client, "lock:contested", WithWatchdog(false))
+
+	ok1, err1 := first.TryLock(context.Background())
+	require.NoError(t, err1)
+	require.True(t, ok1)
+
+	ok2, err2 := second.TryLock(context.Background())
+
+	assert.NoError(t, err2)
+	assert.False(t, ok2)
 }

--- a/go-middleware/redis/lock_test.go
+++ b/go-middleware/redis/lock_test.go
@@ -1,0 +1,52 @@
+package redis
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	goredis "github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestRedisClient(t *testing.T) (*miniredis.Miniredis, goredis.UniversalClient) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := goredis.NewClient(&goredis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	return mr, client
+}
+
+func TestNewMutex_Defaults(t *testing.T) {
+	_, client := newTestRedisClient(t)
+
+	m := NewMutex(client, "lock:test")
+
+	assert.Equal(t, "lock:test", m.key)
+	assert.Equal(t, defaultMutexTTL, m.ttl)
+	assert.Equal(t, defaultRetryInterval, m.retryInterval)
+	assert.True(t, m.watchdog)
+}
+
+func TestNewMutex_CustomOptions(t *testing.T) {
+	_, client := newTestRedisClient(t)
+
+	m := NewMutex(client, "lock:test",
+		WithTTL(5*time.Second),
+		WithRetryInterval(20*time.Millisecond),
+		WithWatchdog(false),
+	)
+
+	assert.Equal(t, 5*time.Second, m.ttl)
+	assert.Equal(t, 20*time.Millisecond, m.retryInterval)
+	assert.False(t, m.watchdog)
+}
+
+func TestMutexOption_IgnoresInvalidValues(t *testing.T) {
+	_, client := newTestRedisClient(t)
+
+	m := NewMutex(client, "lock:test", WithTTL(0), WithRetryInterval(-1))
+
+	assert.Equal(t, defaultMutexTTL, m.ttl)
+	assert.Equal(t, defaultRetryInterval, m.retryInterval)
+}


### PR DESCRIPTION
## Summary
- go-middleware/redis 新增分布式锁 Mutex（单实例 SET NX PX + Lua 原子释放脚本 + watchdog 自动续期）
- 新增限流器 Limiter（令牌桶算法，Lua 脚本原子实现，API 对齐 golang.org/x/time/rate.Limiter 的 Allow/AllowN/Wait）
- 新增错误码 CodeLockAcquire=20103、CodeLockRelease=20104、CodeLimiterEval=20105

## 交付过程
- 10 个任务通过 TDD + 逐任务 review（含一次 Task 8 修复轮：ttlMillis 在 rate<=0 时的溢出问题）
- 最终全分支 review 发现 5 个 Important + 9 个 Minor，已完成一次性修复（AllowN 负数 n 防护、Wait/Lock 错误处理一致性、Limiter 构造参数 clamp、godoc 用法示例、WithTTL/WithRetryInterval 重命名为 WithMutexTTL/WithMutexRetryInterval 避免命名空间冲突），并通过 scoped re-review 确认全部解决
- 剩余 8 个 Minor 已记录为后续可跟进项（不阻塞合并），详见设计文档与实现计划

## Test plan
- [x] go build ./go-common/... ./go-auth/... ./go-middleware/... ./go-framework/...
- [x] go vet 同上
- [x] go test ./go-common/... ./go-auth/... ./go-middleware/... ./go-framework/... -count=1 -race（全部通过）
- [x] gofmt -l 无输出
- [ ] golangci-lint v2（本地环境为 v1.64.8，与仓库 v2 配置不兼容，仓库既有问题，需 CI 验证）

设计文档：docs/superpowers/specs/2026-08-31-redis-lock-limiter-design.md
实现计划：docs/superpowers/plans/2026-08-31-redis-lock-limiter.md

Closes #56