### PR TITLE
docs(go-tools): 同步 CLAUDE.md 子包清单与实际代码

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ The 5-module → 3-library split (2026-06-23) is **complete**. ncgo generated pr
 
 ```text
                     go-common    ← 最底层，零框架依赖
-                        ↑          (crypto, cache, httpclient, log, timeutil, netutil, captcha, error)
+                        ↑          (crypto, cache, httpclient, log, timeutil, netutil, captcha, error, auth, astutil, executil, templateutil)
                      go-auth       ← 认证工具 (JWT, Session/Device 接口, 错误码)
                     ↑       ↑
           ┌─────────┘       └─────────┐
@@ -26,7 +26,7 @@ The 5-module → 3-library split (2026-06-23) is **complete**. ncgo generated pr
 
 | Module | Import Path | Purpose |
 |--------|------------|---------|
-| `go-common` | `github.com/byx-darwin/go-tools/go-common` | Pure utilities: crypto, cache, log, error, timeutil, netutil, httpclient, captcha |
+| `go-common` | `github.com/byx-darwin/go-tools/go-common` | Pure utilities: crypto, cache, log, error, timeutil, netutil, httpclient, captcha, auth, astutil, executil, templateutil |
 | `go-auth` | `github.com/byx-darwin/go-tools/go-auth` | Auth utilities: JWT Sign/Verify/Refresh, Session/Device interfaces |
 | `go-middleware` | `github.com/byx-darwin/go-tools/go-middleware` | Middleware clients: redis, kafka, db, es, clickhouse, tls, auth |
 | `go-framework` | `github.com/byx-darwin/go-tools/go-framework` | Framework adapters: hertz, kitex, config |
@@ -109,12 +109,15 @@ go.work                    → Workspace root (go 1.25.8)
 go-common/                 → Zero-dependency utilities
   cache/                   → Generic cache (samber/hot wrapper): LRU/LFU/FIFO/TwoQueue/ARC
   captcha/                 → CAPTCHA generation with cache
-  crypto/                  → Encryption (MD5/SHA/HMAC/TEA)
+  crypto/                  → Encryption (MD5/SHA/HMAC/AES-GCM)
   httpclient/              → HTTP client with retry, m3u8 support
   log/                     → Structured logging (slog + lumberjack + OTel)
   netutil/                 → Network utilities
   timeutil/                → Time formatting helpers
   auth/                    → Auth helpers (AK/SK)
+  astutil/                 → Go AST manipulation (dave/dst-based, codegen helper)
+  executil/                → Enhanced command execution wrapper
+  templateutil/            → Pluggable template helper functions
   error/                   → Error mechanism (oops Builder/Extract + band boundaries + HTTP status registry)
 go-middleware/             → Middleware clients (no Hertz/Kitex dependency)
   redis/                   → Redis client (go-redis v9, UniversalClient)

--- a/docs/superpowers/plans/2026-09-01-sync-claude-md-package-list.md
+++ b/docs/superpowers/plans/2026-09-01-sync-claude-md-package-list.md
@@ -1,0 +1,177 @@
+# CLAUDE.md 子包清单同步 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 消除 `CLAUDE.md` / `specs/00_overview.md` / `specs/01_split_plan_summary.md` 中记录的 go-common 子包清单、TEA 加密能力与实际代码之间的脱节。
+
+**Architecture:** 纯文档修改，不涉及代码变更。逐文件核对实际目录结构（`go-common/*`）与实际导出函数（`crypto` 包），修正三处文档，并核查 `specs/02-08` 是否存在类似问题（已核查：无）。
+
+**Tech Stack:** Markdown 文档编辑。
+
+**Spec:** Issue #60 — https://github.com/byx-darwin/go-tools/issues/60
+
+## Global Constraints
+
+- 仅修改文档，不改动 `go-common/*` 任何 `.go` 文件。
+- TEA 算法当前未实现（`go-common/crypto/` 仅有 `encrypt.go`: MD5/SHA1/SHA256/SHA512/Hmac/HMACSHA256/EncodePwd；`aes.go`: AES-GCM）——按 Issue AC，移除"已支持 TEA"的表述，不在本 Issue 内实现 TEA。
+- 已核查 `specs/02_config_schema_alignment.md` ~ `specs/08_hertz_response_redesign.md`：均不含 `astutil`/`executil`/`templateutil`/`TEA` 相关表述，无需修改。
+
+---
+
+### Task 1: 修正 CLAUDE.md 子包清单与 crypto 能力描述
+
+**Files:**
+- Modify: `CLAUDE.md:15`（Structure 代码块，go-common 子包括号列表）
+- Modify: `CLAUDE.md:29`（Module 表格，`go-common` 行 Purpose 列）
+- Modify: `CLAUDE.md:112`（Workspace Layout 代码块，`crypto/` 行注释）
+- Modify: `CLAUDE.md:109-118`（Workspace Layout 代码块，补充 `astutil/`、`executil/`、`templateutil/` 三行）
+
+**Interfaces:**
+- 无代码接口，纯文本替换。
+
+- [ ] **Step 1: 核对当前 go-common 实际子包**
+
+已核对（本计划编写时执行）：`go-common/` 下实际子包为 `astutil, auth, cache, captcha, crypto, error, executil, httpclient, log, netutil, templateutil, timeutil`（12 个，均有 `go.mod` 同级目录，非独立 module，是同一 module 内的子包）。
+
+- [ ] **Step 2: 修改 CLAUDE.md:15**
+
+当前内容：
+```
+                        ↑          (crypto, cache, httpclient, log, timeutil, netutil, captcha, error)
+```
+
+替换为：
+```
+                        ↑          (crypto, cache, httpclient, log, timeutil, netutil, captcha, error, auth, astutil, executil, templateutil)
+```
+
+- [ ] **Step 3: 修改 CLAUDE.md:29**
+
+当前内容：
+```
+| `go-common` | `github.com/byx-darwin/go-tools/go-common` | Pure utilities: crypto, cache, log, error, timeutil, netutil, httpclient, captcha |
+```
+
+替换为：
+```
+| `go-common` | `github.com/byx-darwin/go-tools/go-common` | Pure utilities: crypto, cache, log, error, timeutil, netutil, httpclient, captcha, auth, astutil, executil, templateutil |
+```
+
+- [ ] **Step 4: 修改 CLAUDE.md:112（crypto 能力描述）**
+
+当前内容：
+```
+  crypto/                  → Encryption (MD5/SHA/HMAC/TEA)
+```
+
+替换为：
+```
+  crypto/                  → Encryption (MD5/SHA/HMAC/AES-GCM)
+```
+
+- [ ] **Step 5: 在 CLAUDE.md Workspace Layout 代码块中补充缺失子包**
+
+在 `CLAUDE.md:117`（`auth/  → Auth helpers (AK/SK)`）之后、`error/` 行之前或之后，按字母顺序插入三行（保持代码块内其余行不变）：
+
+```
+  astutil/                 → Go AST manipulation (dave/dst-based, codegen helper)
+  executil/                → Enhanced command execution wrapper
+  templateutil/            → Pluggable template helper functions
+```
+
+最终 `go-common/` 代码块段（`CLAUDE.md:109-118`）应为：
+```
+go-common/                 → Zero-dependency utilities
+  cache/                   → Generic cache (samber/hot wrapper): LRU/LFU/FIFO/TwoQueue/ARC
+  captcha/                 → CAPTCHA generation with cache
+  crypto/                  → Encryption (MD5/SHA/HMAC/AES-GCM)
+  httpclient/              → HTTP client with retry, m3u8 support
+  log/                     → Structured logging (slog + lumberjack + OTel)
+  netutil/                 → Network utilities
+  timeutil/                → Time formatting helpers
+  auth/                    → Auth helpers (AK/SK)
+  astutil/                 → Go AST manipulation (dave/dst-based, codegen helper)
+  executil/                → Enhanced command execution wrapper
+  templateutil/            → Pluggable template helper functions
+  error/                   → Error mechanism (oops Builder/Extract + band boundaries + HTTP status registry)
+```
+
+- [ ] **Step 6: 校验 Markdown 渲染无误**
+
+Run: `grep -n "astutil\|executil\|templateutil" CLAUDE.md`
+Expected: 命中 Step 2/3/5 新增的行，共 3+ 处。
+
+Run: `grep -n "TEA" CLAUDE.md`
+Expected: 无命中（TEA 描述已移除）。
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(go-tools): sync CLAUDE.md go-common package list with actual code (#60)"
+```
+
+---
+
+### Task 2: 修正 specs/00_overview.md 与 specs/01_split_plan_summary.md 的 TEA 描述
+
+**Files:**
+- Modify: `specs/00_overview.md:38`
+- Modify: `specs/01_split_plan_summary.md:42`
+- Modify: `specs/01_split_plan_summary.md:146`
+
+**Interfaces:**
+- 无代码接口，纯文本替换。
+
+- [ ] **Step 1: 修改 specs/00_overview.md:38**
+
+当前内容：
+```
+| `crypto` | 加密（MD5/SHA/HMAC/TEA） |
+```
+
+替换为：
+```
+| `crypto` | 加密（MD5/SHA/HMAC/AES-GCM） |
+```
+
+- [ ] **Step 2: 修改 specs/01_split_plan_summary.md:42**
+
+当前内容：
+```
+| `tools/crypto/*` | `go-common/crypto/` | MD5/SHA/HMAC/TEA |
+```
+
+替换为：
+```
+| `tools/crypto/*` | `go-common/crypto/` | MD5/SHA/HMAC/AES-GCM |
+```
+
+- [ ] **Step 3: 修改 specs/01_split_plan_summary.md:146**
+
+先读取该行上下文（前后各 10 行），确认这是一段 API 签名示例代码块。当前内容：
+```
+func TEAEncrypt(data, key []byte) ([]byte, error)
+```
+
+删除该行（TEA 从未实现，属于过时的历史规划签名，不应保留在"已确认接口"示例中）。若该代码块删除此行后括号/代码围栏不完整，需同步调整围栏结构，保持代码块语法合法。
+
+- [ ] **Step 4: 校验**
+
+Run: `grep -rn "TEA" specs/00_overview.md specs/01_split_plan_summary.md`
+Expected: 无命中。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add specs/00_overview.md specs/01_split_plan_summary.md
+git commit -m "docs(specs): remove unimplemented TEA references from spec 00/01 (#60)"
+```
+
+---
+
+## Self-Review Notes (completed during plan authoring)
+
+- **Spec coverage:** AC1（子包清单同步）→ Task 1；AC2（移除/修正 TEA 描述）→ Task 2；AC3（核查 00-08 其他脱节）→ 已在 Global Constraints 中记录核查结果（02-08 无问题，无需新增 Task）。
+- **Placeholder scan:** 无 TBD/TODO，所有替换文本均为完整最终内容。
+- **Type consistency:** 不适用（纯文档任务，无代码接口）。

--- a/specs/00_overview.md
+++ b/specs/00_overview.md
@@ -35,7 +35,7 @@
 | `log` | 结构化日志（基于 slog + OTel TraceID/SpanID + 文件轮转） |
 | `log/adapters` | Hertz/Kitex 日志适配器 |
 | `netutil` | 网络工具（内网 IP 获取） |
-| `crypto` | 加密（MD5/SHA/HMAC/TEA） |
+| `crypto` | 加密（MD5/SHA/HMAC/AES-GCM） |
 | `httpclient` | HTTP 客户端（重试/M3U8） |
 | `auth` | AK/SK 生成 |
 | `timeutil` | 时间工具 |

--- a/specs/01_split_plan_summary.md
+++ b/specs/01_split_plan_summary.md
@@ -39,7 +39,7 @@ go-middleware              go-framework
 
 | 来源 | 目标路径 | 说明 |
 |------|---------|------|
-| `tools/crypto/*` | `go-common/crypto/` | MD5/SHA/HMAC/TEA |
+| `tools/crypto/*` | `go-common/crypto/` | MD5/SHA/HMAC/AES-GCM |
 | `tools/cache/*` | `go-common/cache/` | 缓存封装 — 底层使用 `github.com/samber/hot`（替代自定义 FIFO/LRU/LFU/CLOCK/MRU 实现） |
 | `tools/http_client/*` | `go-common/httpclient/` | fasthttp 客户端 + 重试 |
 | `tools/time/*` | `go-common/timeutil/` | 时间格式化/月份 |
@@ -143,7 +143,6 @@ func NewCache[K comparable, V any](policy hot.Policy, size int) *hot.HotCache[K,
 func MD5(data []byte) string
 func SHA256(data []byte) string
 func HMACSHA256(data, key []byte) string
-func TEAEncrypt(data, key []byte) ([]byte, error)
 
 // go-common/log/logger.go — 基于 Go 标准库 log/slog，零外部日志依赖
 type Logger struct { *slog.Logger; config *Config }


### PR DESCRIPTION
## Summary

同步文档与实际代码，消除"文档承诺"与"实际实现"之间的不一致（见 #60）：

- `CLAUDE.md`：go-common 子包清单补充 `auth`/`astutil`/`executil`/`templateutil`（Structure 图、Module 表格、Workspace Layout 代码块三处），并将 `crypto` 能力描述从未实现的 `TEA` 修正为实际支持的 `AES-GCM`。
- `specs/00_overview.md`、`specs/01_split_plan_summary.md`：移除/修正 TEA 相关的过时描述（含删除一条从未实现的 `TEAEncrypt` API 签名示例）。
- 已核查 `specs/02_config_schema_alignment.md` ~ `specs/08_hertz_response_redesign.md`：无类似脱节，未做改动。

纯文档修改，不涉及任何 `.go` 代码变更。

Closes #60

## Test plan

- [x] `go build ./go-common/... ./go-auth/... ./go-middleware/... ./go-framework/...` — 通过（docs-only，构建不受影响）
- [x] `grep -rn "TEA" CLAUDE.md specs/00_overview.md specs/01_split_plan_summary.md` — 无命中
- [x] 逐条核对 `go-common/` 实际子包目录与 CLAUDE.md 新增清单一致