### PR TITLE
docs(go-common): 移除 README 中残留的 TEA 加密描述

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -83,7 +83,7 @@ Docker Compose 服务定义（[docker-compose.yml](./docker-compose.yml)）：
 
 | Method | Path | 功能 |
 |--------|------|------|
-| `GET` | `/common/crypto` | MD5、SHA256、SHA512、HMAC、TEA 加密演示 |
+| `GET` | `/common/crypto` | MD5、SHA256、SHA512、HMAC、AES-GCM 加密演示 |
 | `GET` | `/common/cache` | LRU / LFU 缓存操作演示 |
 | `GET` | `/common/captcha` | 生成图形验证码（返回 ID + Base64 图片） |
 | `POST` | `/common/captcha/verify` | 校验验证码 |

--- a/go-common/README.md
+++ b/go-common/README.md
@@ -15,7 +15,7 @@ go get github.com/byx-darwin/go-tools/go-common
 | `auth` | AK/SK 生成与刷新 |
 | `cache` | 泛型缓存（基于 `github.com/samber/hot`，LRU/LFU/FIFO/TwoQueue/ARC + TTL） |
 | `captcha` | 验证码缓存存储 |
-| `crypto` | MD5 / SHA1 / SHA256 / SHA512 / HMAC-SHA256 / TEA 加解密 |
+| `crypto` | MD5 / SHA1 / SHA256 / SHA512 / HMAC-SHA256 / AES-GCM 加解密 |
 | `httpclient` | fasthttp HTTP 客户端 + 重试 + m3u8 下载 |
 | `log` | 结构化日志（基于 `log/slog`，JSON/Text 输出，OTel span 关联） |
 | `log/adapters` | Kitex klog / Hertz hlog 适配器 |
@@ -27,5 +27,4 @@ go get github.com/byx-darwin/go-tools/go-common
 - Go 标准库 `log/slog`
 - `github.com/samber/hot` — 缓存底层
 - `github.com/valyala/fasthttp` — HTTP 客户端
-- `golang.org/x/crypto` — TEA 加密
 - `go.opentelemetry.io/otel/trace` — OTel span 关联


### PR DESCRIPTION
## Summary
- 修正 `go-common/README.md` 能力表格：`crypto` 包 TEA → AES-GCM
- 移除 `go-common/README.md` 依赖列表中错误的 `golang.org/x/crypto` — TEA 加密 条目（该依赖实际未被使用，AES-GCM 基于标准库 `crypto/aes`）
- 修正 `example/README.md` API 演示表格：TEA → AES-GCM

## Context
PR #66（关联 Issue #60）已修正 CLAUDE.md 与 specs 中的 TEA 描述，本次补齐分支评审中发现遗漏的 2 个 README 文件。

Closes #67

## Test plan
- [x] `grep -rni tea go-common/README.md example/README.md` 确认无残留引用
- [x] 核对 `go-common/crypto` 实际导出函数（MD5/SHA1/SHA256/SHA512/HMAC/AES-GCM），无 TEA 实现
- [x] 核对 `example/handler/common_crypto.go` 实际使用 `crypto.NewAESGCM`，与更新后描述一致
- [x] `go-common/go.mod` 确认无 `golang.org/x/crypto` 依赖