### PR TITLE
feat(go-common/log): enable default masking baseline in NewConfig

### DIFF
--- a/go-common/log/config.go
+++ b/go-common/log/config.go
@@ -64,6 +64,11 @@ type CategoryConfig struct {
 }
 
 // MaskConfig 敏感数据脱敏配置。
+//
+// 经 NewConfig() 构造时默认 Enabled=true 并附带 DefaultMaskedFields()
+// 基线字段；直接使用 MaskConfig{} 零值字面量则默认关闭（Enabled=false）。
+// WithConfigMasking 会整体替换该结构体，若需在默认基础上追加自定义字段，
+// 调用方应显式传入 MaskConfig{Enabled: true, MaskedFields: append(DefaultMaskedFields(), "custom_field"), Mode: "full"}。
 type MaskConfig struct {
 	// Enabled 是否启用脱敏。
 	Enabled bool `yaml:"enabled" json:"enabled"`
@@ -128,7 +133,8 @@ func WithConfigCategories(categories map[string]CategoryConfig) ConfigOption {
 	}
 }
 
-// WithConfigMasking 设置脱敏配置。
+// WithConfigMasking 设置脱敏配置（整体替换，与 WithConfigFile 一致）。
+// 传入 MaskConfig{Enabled: false} 可显式关闭 NewConfig 的默认脱敏基线。
 func WithConfigMasking(masking MaskConfig) ConfigOption {
 	return func(c *Config) {
 		c.Masking = masking
@@ -141,12 +147,22 @@ func WithConfigMasking(masking MaskConfig) ConfigOption {
 //   - level: "info"
 //   - format: "json"
 //   - mode: "console"
+//   - masking: 启用，使用 DefaultMaskedFields() 默认字段列表，mode "full"
+//
+// 注意：仅通过 NewConfig 构造时应用上述默认值；直接使用 Config{} 零值字面量
+// 不会自动启用脱敏（Masking.Enabled 保持 false），与 Level/Format/Mode 的
+// 现有约定一致。
 func NewConfig(opts ...ConfigOption) Config {
 	cfg := Config{
 		Level:  defaultConfigLevel,
 		Format: defaultConfigFormat,
 		Mode:   defaultConfigMode,
 		File:   NewFileConfig(),
+		Masking: MaskConfig{
+			Enabled:      true,
+			MaskedFields: DefaultMaskedFields(),
+			Mode:         defaultMaskMode,
+		},
 	}
 	for _, opt := range opts {
 		opt(&cfg)
@@ -236,4 +252,7 @@ const (
 	defaultFileMaxSize    = 100
 	defaultFileMaxBackups = 7
 	defaultFileMaxAge     = 30
+
+	// defaultMaskMode 默认脱敏模式（NewConfig 使用）。
+	defaultMaskMode = "full"
 )

--- a/go-common/log/config_test.go
+++ b/go-common/log/config_test.go
@@ -14,7 +14,30 @@ func TestConfig_Defaults(t *testing.T) {
 	require.Equal(t, "console", cfg.Mode)
 	require.False(t, cfg.AddSource)
 	require.Empty(t, cfg.Categories)
+	require.True(t, cfg.Masking.Enabled)
+	require.NotEmpty(t, cfg.Masking.MaskedFields)
+	require.Equal(t, "full", cfg.Masking.Mode)
+}
+
+func TestNewConfig_DefaultMaskingEnabled(t *testing.T) {
+	cfg := log.NewConfig()
+	require.True(t, cfg.Masking.Enabled)
+	require.Equal(t, log.DefaultMaskedFields(), cfg.Masking.MaskedFields)
+	require.Equal(t, "full", cfg.Masking.Mode)
+}
+
+func TestWithConfigMasking_ExplicitDisable(t *testing.T) {
+	cfg := log.NewConfig(
+		log.WithConfigMasking(log.MaskConfig{Enabled: false}),
+	)
 	require.False(t, cfg.Masking.Enabled)
+	require.Empty(t, cfg.Masking.MaskedFields)
+}
+
+func TestMaskConfig_ZeroValueUnaffected(t *testing.T) {
+	var cfg log.Config
+	require.False(t, cfg.Masking.Enabled)
+	require.Empty(t, cfg.Masking.MaskedFields)
 }
 
 func TestConfig_CustomValues(t *testing.T) {

--- a/go-common/log/mask.go
+++ b/go-common/log/mask.go
@@ -10,6 +10,22 @@ type Masker struct {
 	config MaskConfig
 }
 
+// defaultMaskedFields 默认脱敏字段基线，仅使用完整词避免误命中
+// task_id / disk_usage / risk_score / bitmask 等无关字段。
+var defaultMaskedFields = []string{
+	"password", "passwd", "secret", "token", "authorization",
+	"credential", "api_key", "apikey", "access_key", "accesskey",
+	"secret_key", "secretkey", "private_key", "privatekey",
+}
+
+// DefaultMaskedFields 返回默认脱敏字段名列表的副本。
+// 用于 NewConfig 的开箱即用脱敏基线，也可供调用方在此基础上追加自定义字段。
+func DefaultMaskedFields() []string {
+	fields := make([]string, len(defaultMaskedFields))
+	copy(fields, defaultMaskedFields)
+	return fields
+}
+
 // NewMasker 创建脱敏器。
 func NewMasker(cfg MaskConfig) *Masker {
 	return &Masker{config: cfg}

--- a/go-common/log/mask_test.go
+++ b/go-common/log/mask_test.go
@@ -97,3 +97,52 @@ func TestMasker_CaseInsensitive(t *testing.T) {
 	masked := masker.Mask(attrs)
 	require.Equal(t, "***", masked[0].Value.String())
 }
+
+func TestDefaultMaskedFields_ContainsExpected(t *testing.T) {
+	fields := log.DefaultMaskedFields()
+	for _, want := range []string{
+		"password", "passwd", "secret", "token", "authorization",
+		"credential", "api_key", "apikey", "access_key", "accesskey",
+		"secret_key", "secretkey", "private_key", "privatekey",
+	} {
+		require.Contains(t, fields, want)
+	}
+}
+
+func TestDefaultMaskedFields_NoFalsePositive(t *testing.T) {
+	cfg := log.MaskConfig{
+		Enabled:      true,
+		MaskedFields: log.DefaultMaskedFields(),
+		Mode:         "full",
+	}
+	masker := log.NewMasker(cfg)
+	attrs := []slog.Attr{
+		slog.String("task_id", "t-1"),
+		slog.String("disk_usage", "42%"),
+		slog.String("risk_score", "0.1"),
+		slog.String("bitmask", "0xFF"),
+	}
+	masked := masker.Mask(attrs)
+	for i, attr := range attrs {
+		require.Equal(t, attr.Value.String(), masked[i].Value.String(), "field %s should not be masked", attr.Key)
+	}
+}
+
+func TestMasker_DefaultFields(t *testing.T) {
+	cfg := log.MaskConfig{
+		Enabled:      true,
+		MaskedFields: log.DefaultMaskedFields(),
+		Mode:         "full",
+	}
+	masker := log.NewMasker(cfg)
+	attrs := []slog.Attr{
+		slog.String("password", "secret123"),
+		slog.String("token", "abc.def.ghi"),
+		slog.String("secret", "topsecret"),
+		slog.String("api_key", "sk-live-xxx"),
+	}
+	masked := masker.Mask(attrs)
+	for i, attr := range masked {
+		require.Equal(t, "***", attr.Value.String(), "field %s should be masked", attrs[i].Key)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `log.DefaultMaskedFields()` returning a safe default list of masking field names (password/passwd/secret/token/authorization/credential/api_key/apikey/access_key/accesskey/secret_key/secretkey/private_key/privatekey).
- `log.NewConfig()` now defaults to `Masking.Enabled = true` with `MaskedFields: DefaultMaskedFields()` and `Mode: "full"`, so downstream services get a safe-by-default masking baseline without needing to configure it explicitly.
- `Config{}` / `MaskConfig{}` bare zero-value literals are unaffected — `Enabled` stays `false`, consistent with the existing convention for `Level`/`Format`/`Mode` (defaults apply only via `NewConfig()`).
- `WithConfigMasking` keeps its whole-struct-replace semantics; pass `WithConfigMasking(MaskConfig{Enabled: false})` to explicitly opt out of the new default baseline.

Closes #61

## Breaking Change

`go-common/log.NewConfig()` 的默认值变更：`Masking.Enabled` 由 `false` 改为 `true`，
并默认附带 `DefaultMaskedFields()` 基线字段（password/token/secret/authorization/
credential/api_key/access_key/secret_key/private_key 等长词，不含 ak/sk 短词以避免
误命中 task_id/disk_usage 等字段）。

**影响范围**：仅影响调用 `log.NewConfig()` 且未显式设置 `Masking` 的下游——这些
调用方原本明文输出的敏感字段现在会被脱敏为 `***`。

**不受影响**：直接使用 `log.Config{}` / `log.MaskConfig{}` 零值字面量构造的调用方
行为不变（`Enabled` 仍为 `false`），与 `Level`/`Format`/`Mode` 现有的
"默认值仅在构造函数中生效"惯例一致。

**如何保留旧行为**：`log.NewConfig(log.WithConfigMasking(log.MaskConfig{Enabled: false}))`。

本仓库 `go-common` 无 `CHANGELOG.md`，此说明作为该变更的唯一记录，请在合并时保留于
PR 描述中。

## Test plan

- [x] `go test ./go-common/log/... -v` (new + existing tests pass)
- [x] `go test ./go-common/... ./go-auth/... ./go-middleware/... ./go-framework/... -count=1`
- [x] `go build ./go-common/... ./go-auth/... ./go-middleware/... ./go-framework/...`
- [x] `go vet ./go-common/...`
- [x] `gofmt -l go-common/log` (no output)
- [x] `golangci-lint run --timeout=5m ./go-common/...` (0 issues)


Closes #61