### PR TITLE
feat(tls): Producer 接入 WithTrace() OTel 追踪

### DIFF
--- a/go-middleware/README.md
+++ b/go-middleware/README.md
@@ -19,7 +19,7 @@ go get github.com/byx-darwin/go-tools/go-middleware
 | `db` | 数据库配置 + 连接池工厂（OTel 追踪，可选） |
 | `es` | Elasticsearch v8 客户端（OTel 追踪，可选） |
 | `clickhouse` | ClickHouse 原生协议客户端（基于 `clickhouse-go/v2`；含包内错误码 20401-20403；OTel 追踪，可选） |
-| `tls` | 火山引擎日志服务（Producer + FileShipper；含包内错误码 20501-20504） |
+| `tls` | 火山引擎日志服务（Producer + FileShipper；含包内错误码 20501-20504；OTel 追踪，可选） |
 
 ## 配置对齐
 

--- a/go-middleware/tls/options.go
+++ b/go-middleware/tls/options.go
@@ -1,0 +1,15 @@
+package tls
+
+import "go.opentelemetry.io/otel"
+
+// ProducerOption 定义 NewProducer 的配置选项函数。
+type ProducerOption func(*Producer)
+
+// WithTrace 启用 OpenTelemetry 追踪：为每次 flush（批量发送）起一个 span，
+// 并把触发本次 flush 的各 SendLog 调用方 span（若携带有效 trace 上下文）
+// 通过 Link 关联到该 span。未启用时 Producer 行为与现状完全一致。
+func WithTrace() ProducerOption {
+	return func(p *Producer) {
+		p.tracer = otel.Tracer(instrumentationName)
+	}
+}

--- a/go-middleware/tls/producer.go
+++ b/go-middleware/tls/producer.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/samber/oops"
 	"github.com/volcengine/volc-sdk-golang/service/tls"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // ProducerConfig 生产者配置
@@ -54,10 +56,16 @@ type Producer struct {
 	// closeErr 保存关闭前最终 flush 的结果，仅由 flushLoop 在 close(done) 之前写入，
 	// Close 在 <-done 之后读取，通过 channel 建立 happens-before，无需额外加锁。
 	closeErr error
+	// tracer 非 nil 时为 flush 记录 span；nil 表示未启用 WithTrace，
+	// SendLog/flush 行为与未接入追踪前完全一致。
+	tracer trace.Tracer
+	// pendingCtx 记录自上次 flush 以来、携带有效 trace 上下文的 SendLog
+	// 调用方 SpanContext，flush 时消费并清空，用于起 span 时建立 Link。
+	pendingCtx []trace.SpanContext
 }
 
 // NewProducer 创建 TLS Producer。
-func NewProducer(cfg ProducerConfig) (*Producer, error) {
+func NewProducer(cfg ProducerConfig, opts ...ProducerOption) (*Producer, error) {
 	if cfg.Endpoint == "" {
 		return nil, oops.With("tls.NewProducer").
 			Code(CodeInvalidConfig).
@@ -91,6 +99,9 @@ func NewProducer(cfg ProducerConfig) (*Producer, error) {
 		closeCh: make(chan struct{}),
 		done:    make(chan struct{}),
 	}
+	for _, opt := range opts {
+		opt(p)
+	}
 
 	go p.flushLoop()
 	return p, nil
@@ -105,6 +116,11 @@ func (p *Producer) SendLog(ctx context.Context, fields map[string]string) error 
 
 	p.mu.Lock()
 	p.buf = append(p.buf, log)
+	if p.tracer != nil {
+		if sc := trace.SpanContextFromContext(ctx); sc.IsValid() {
+			p.pendingCtx = append(p.pendingCtx, sc)
+		}
+	}
 	needFlush := len(p.buf) >= p.config.BatchSize
 	p.mu.Unlock()
 
@@ -129,28 +145,42 @@ func (p *Producer) Flush(ctx context.Context) error {
 	return p.flush(ctx)
 }
 
-func (p *Producer) flush(_ context.Context) error {
+func (p *Producer) flush(ctx context.Context) (err error) {
 	p.mu.Lock()
 	if len(p.buf) == 0 {
 		p.mu.Unlock()
 		return nil
 	}
 	logs := p.buf
+	links := p.pendingCtx
 	p.buf = make([]tls.Log, 0, p.config.BatchSize)
+	p.pendingCtx = nil
 	p.mu.Unlock()
 
-	_, err := p.client.PutLogsV2(&tls.PutLogsV2Request{
+	if p.tracer != nil {
+		var span trace.Span
+		_, span = p.tracer.Start(ctx, "tls.flush",
+			trace.WithLinks(spanLinks(links)...),
+			trace.WithAttributes(
+				attribute.String("tls.topic_id", p.config.TopicID),
+				attribute.Int("tls.batch_size", len(logs)),
+			),
+		)
+		defer func() { endSpan(span, err) }()
+	}
+
+	_, err = p.client.PutLogsV2(&tls.PutLogsV2Request{
 		TopicID:      p.config.TopicID,
 		CompressType: "lz4",
 		Source:       p.config.Source,
 		Logs:         logs,
 	})
 	if err != nil {
-		return oops.With("tls.flush").
+		err = oops.With("tls.flush").
 			Code(CodeSend).
 			Wrap(err)
 	}
-	return nil
+	return err
 }
 
 func (p *Producer) flushLoop() {

--- a/go-middleware/tls/trace.go
+++ b/go-middleware/tls/trace.go
@@ -1,0 +1,36 @@
+package tls
+
+import (
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// instrumentationName OTel instrumentation 标识。
+const instrumentationName = "github.com/byx-darwin/go-tools/go-middleware/tls"
+
+// endSpan 出错时记录错误并设置 span 状态，最终结束 span。
+func endSpan(span trace.Span, err error) {
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
+	span.End()
+}
+
+// spanLinks 把待关联的 SpanContext 按 SpanID 去重后转换为 trace.Link，
+// 用于关联触发本次 flush 的各 SendLog 调用方 span。
+func spanLinks(scs []trace.SpanContext) []trace.Link {
+	if len(scs) == 0 {
+		return nil
+	}
+	seen := make(map[trace.SpanID]struct{}, len(scs))
+	links := make([]trace.Link, 0, len(scs))
+	for _, sc := range scs {
+		if _, ok := seen[sc.SpanID()]; ok {
+			continue
+		}
+		seen[sc.SpanID()] = struct{}{}
+		links = append(links, trace.Link{SpanContext: sc})
+	}
+	return links
+}

--- a/go-middleware/tls/trace_test.go
+++ b/go-middleware/tls/trace_test.go
@@ -1,0 +1,32 @@
+package tls
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestSpanLinks_Deduplicates(t *testing.T) {
+	sc1 := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    trace.TraceID{1},
+		SpanID:     trace.SpanID{1},
+		TraceFlags: trace.FlagsSampled,
+	})
+	sc2 := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    trace.TraceID{2},
+		SpanID:     trace.SpanID{2},
+		TraceFlags: trace.FlagsSampled,
+	})
+
+	links := spanLinks([]trace.SpanContext{sc1, sc1, sc2})
+
+	require.Len(t, links, 2)
+	require.Equal(t, sc1, links[0].SpanContext)
+	require.Equal(t, sc2, links[1].SpanContext)
+}
+
+func TestSpanLinks_EmptyInput(t *testing.T) {
+	links := spanLinks(nil)
+	require.Empty(t, links)
+}

--- a/go-middleware/tls/trace_test.go
+++ b/go-middleware/tls/trace_test.go
@@ -1,9 +1,16 @@
 package tls
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -29,4 +36,100 @@ func TestSpanLinks_Deduplicates(t *testing.T) {
 func TestSpanLinks_EmptyInput(t *testing.T) {
 	links := spanLinks(nil)
 	require.Empty(t, links)
+}
+
+func attrsToMap(attrs []attribute.KeyValue) map[string]any {
+	m := make(map[string]any, len(attrs))
+	for _, a := range attrs {
+		m[string(a.Key)] = a.Value.AsInterface()
+	}
+	return m
+}
+
+func newTestProducer(t *testing.T, opts ...ProducerOption) *Producer {
+	t.Helper()
+	p, err := NewProducer(ProducerConfig{
+		Endpoint:        "tls.example.com", // 不可达域名，flush 一定失败，仅验证 span 行为
+		AccessKeyID:     "ak",
+		AccessKeySecret: "sk",
+		Region:          "cn-beijing",
+		TopicID:         "topic-123",
+		BatchSize:       1, // 每次 SendLog 立即触发 flush
+		FlushInterval:   time.Hour,
+	}, opts...)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = p.Close() })
+	return p
+}
+
+func TestProducer_Flush_TracesSpanWithAttributesOnFailure(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	p := newTestProducer(t, WithTrace())
+	p.tracer = tp.Tracer(instrumentationName)
+
+	err := p.SendLog(context.Background(), map[string]string{"level": "info"})
+	require.Error(t, err) // fake endpoint: 网络必然失败
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+	assert.Equal(t, "tls.flush", spans[0].Name)
+	assert.Equal(t, codes.Error, spans[0].Status.Code)
+
+	attrs := attrsToMap(spans[0].Attributes)
+	assert.Equal(t, "topic-123", attrs["tls.topic_id"])
+	assert.EqualValues(t, 1, attrs["tls.batch_size"])
+}
+
+func TestProducer_Flush_NoTraceProducesNoSpans(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	p := newTestProducer(t) // 未启用 WithTrace，p.tracer 为 nil
+
+	_ = p.SendLog(context.Background(), map[string]string{"level": "info"})
+
+	assert.Empty(t, exporter.GetSpans(), "tracing 未启用时不应产生任何 span")
+}
+
+func TestProducer_SendLog_LinksCallerSpanToFlush(t *testing.T) {
+	callerExporter := tracetest.NewInMemoryExporter()
+	callerTP := sdktrace.NewTracerProvider(sdktrace.WithSyncer(callerExporter))
+	t.Cleanup(func() { _ = callerTP.Shutdown(context.Background()) })
+	callerCtx, callerSpan := callerTP.Tracer("caller").Start(context.Background(), "handle-request")
+
+	flushExporter := tracetest.NewInMemoryExporter()
+	flushTP := sdktrace.NewTracerProvider(sdktrace.WithSyncer(flushExporter))
+	t.Cleanup(func() { _ = flushTP.Shutdown(context.Background()) })
+
+	p := newTestProducer(t, WithTrace())
+	p.tracer = flushTP.Tracer(instrumentationName)
+
+	_ = p.SendLog(callerCtx, map[string]string{"level": "info"})
+	callerSpan.End()
+
+	spans := flushExporter.GetSpans()
+	require.Len(t, spans, 1)
+	require.Len(t, spans[0].Links, 1)
+	assert.Equal(t, callerSpan.SpanContext().TraceID(), spans[0].Links[0].SpanContext.TraceID())
+	assert.Equal(t, callerSpan.SpanContext().SpanID(), spans[0].Links[0].SpanContext.SpanID())
+}
+
+func TestProducer_SendLog_NoSpanContextProducesNoLinks(t *testing.T) {
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	p := newTestProducer(t, WithTrace())
+	p.tracer = tp.Tracer(instrumentationName)
+
+	// 模拟 flushLoop / FileShipper 场景：ctx 不携带业务 span。
+	_ = p.SendLog(context.Background(), map[string]string{"level": "info"})
+
+	spans := exporter.GetSpans()
+	require.Len(t, spans, 1)
+	assert.Empty(t, spans[0].Links)
 }


### PR DESCRIPTION
## Summary
- 给 `go-middleware/tls` 的 `Producer` 接入 `WithTrace()` OpenTelemetry 追踪，与 `db`/`es`/`clickhouse`/`kafka` 四个包的追踪风格保持一致
- 新增 `go-middleware/tls/trace.go`（`instrumentationName`/`endSpan`/`spanLinks`）与 `go-middleware/tls/options.go`（`ProducerOption`/`WithTrace()`）
- `Producer.flush` 在启用追踪时起 `tls.flush` span，并通过 `trace.WithLinks` 关联触发本次 flush 的各 `SendLog` 调用方 span 上下文；未启用 `WithTrace()` 时行为与现状完全一致（零开销、零行为变化）
- 同步更新 `go-middleware/README.md` tls 包一览，标注 OTel 追踪（可选）

Closes #54

## Test plan
- [x] `go test ./go-middleware/tls/... -v`（新增 6 个测试全部通过，含 span 属性、Link 关联、无追踪/无上下文退化场景，以及既有 producer/shipper/errors 测试均通过）
- [x] `gofmt -l go-middleware/tls/*.go`
- [x] `go build ./go-middleware/...`
- [x] `go vet ./go-middleware/...`
- [x] `golangci-lint run --timeout=5m ./go-middleware/...`（0 issues）
- [x] `go test ./go-middleware/... -count=1`
- [x] `go build ./go-common/... ./go-auth/... ./go-middleware/... ./go-framework/...`
- [x] `go vet ./go-common/... ./go-auth/... ./go-middleware/... ./go-framework/...`
- [x] `go test ./go-common/... ./go-auth/... ./go-middleware/... ./go-framework/... -count=1`


Closes #54