### PR TITLE
docs(go-common/crypto): 为 EncodePwd/MD5/SHA1 补充安全告诫

### DIFF
--- a/go-common/crypto/encrypt.go
+++ b/go-common/crypto/encrypt.go
@@ -15,6 +15,9 @@ import (
 )
 
 // SHA1 返回 content 的 SHA-1 十六进制摘要。
+//
+// 安全告诫：SHA-1 已被证明存在碰撞攻击，且不带盐、非慢哈希，不得用于密码存储、
+// 数字签名等安全敏感场景，仅适用于校验和、去重等非安全用途。
 func SHA1(content []byte) string {
 	h := sha1.New()
 	h.Write(content)
@@ -29,6 +32,9 @@ func SHA512(content []byte) string {
 }
 
 // MD5 返回 content 的 MD5 十六进制摘要。
+//
+// 安全告诫：MD5 已被证明存在碰撞攻击，且不带盐、非慢哈希，不得用于密码存储、
+// 数字签名等安全敏感场景，仅适用于校验和、去重等非安全用途。
 func MD5(content []byte) string {
 	return fmt.Sprintf("%x", md5.Sum(content))
 }
@@ -53,6 +59,11 @@ func HMACSHA256(data, key []byte) string {
 }
 
 // EncodePwd 使用 ak 作为密钥对 password 进行 HMAC-SHA256 编码。
+//
+// 安全告诫：本函数底层是 HMAC-SHA256，属于快速哈希算法，不带盐、不支持可调
+// 工作因子，不具备专用密码哈希算法（如 bcrypt/scrypt/argon2）应有的抗暴力
+// 破解特性。不得直接用于用户密码的存储或校验；如需安全的密码哈希方案，请
+// 使用 bcrypt/scrypt/argon2 等专用算法（当前仓库未内置封装）。
 func EncodePwd(password, ak string) string {
 	return Hmac([]byte(ak), []byte(password), sha256.New)
 }


### PR DESCRIPTION
## Summary

- `EncodePwd` 底层是 HMAC-SHA256，属于快速哈希算法，不具备专用密码哈希算法（bcrypt/scrypt/argon2）应有的抗暴力破解特性，容易被误认为可安全用于密码存储。为其补充 godoc 安全告诫，说明实现方式及不适合直接用于密码存储的原因。
- `MD5` / `SHA1` 同样不带盐、非慢哈希，已被证明存在碰撞攻击，补充"不得用于密码存储/签名等安全敏感场景"的告诫。
- 评估结论：本次不引入 bcrypt/argon2 等新依赖（属于行为/依赖变更，超出本 docs 任务范围），如需专用密码哈希函数请另开 Issue 跟进，已在 `EncodePwd` godoc 中给出方向性建议。

## Test plan

- [x] `gofmt -l go-common/crypto/encrypt.go`（无输出）
- [x] `go build ./go-common/...`
- [x] `go vet ./go-common/...`
- [x] `golangci-lint run ./go-common/...`（0 issues）
- [x] `go test ./go-common/crypto/... -count=1`

Closes #62