### PR TITLE
fix(auth): WithIssuer 在 Verify 路径未生效，存在越权风险

### DIFF
--- a/docs/superpowers/plans/2026-09-02-jwt-verify-issuer-plan.md
+++ b/docs/superpowers/plans/2026-09-02-jwt-verify-issuer-plan.md
@@ -1,0 +1,223 @@
+# JWT Verify Issuer Validation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `jwt.Verify` actually enforce issuer validation via a new `WithExpectedIssuer` option, without changing `WithIssuer`'s existing Sign-only behavior or breaking `Refresh`.
+
+**Architecture:** Add a new `Option` (`WithExpectedIssuer`) that sets a new `config.expectedIssuer` field; `Verify` passes `gojwt.WithIssuer(cfg.expectedIssuer)` as a `ParserOption` to `gojwt.ParseWithClaims` when that field is non-empty. `WithIssuer` is untouched functionally — only its godoc gains a clarifying note. The two options are orthogonal, so `Refresh` (which reuses `opts` for both its internal `Verify` and its final `Sign`) needs no code changes.
+
+**Tech Stack:** Go 1.25 workspace, `golang-jwt/jwt/v5` (`gojwt.WithIssuer(iss string) ParserOption`), `samber/oops`, `testify`.
+
+**Spec:** `docs/superpowers/specs/2026-09-02-jwt-verify-issuer-design.md`
+
+## Global Constraints
+
+- `go-auth` may only import `go-common` (unaffected here — no new imports needed beyond what's already imported).
+- All exported symbols need godoc comments starting with the symbol name (revive linter).
+- All error returns must be handled (errcheck) — no new error-wrap sites are introduced by this change; the existing `mapJWTError` default branch already handles the new failure mode.
+- gofmt-clean, 3-group import ordering (stdlib / third-party / local) — no import changes needed in `token.go` (`gojwt` is already imported) or `options.go` (`gojwt` is already imported).
+- Use `any` not `interface{}` — n/a, no new interface-typed params here.
+
+---
+
+## Task 1: Add `WithExpectedIssuer` option and wire it into `Verify`
+
+**Files:**
+- Modify: `go-auth/jwt/options.go` (config struct, new `WithExpectedIssuer` function, `WithIssuer` godoc)
+- Modify: `go-auth/jwt/token.go:61-102` (`Verify` function)
+- Test: `go-auth/jwt/token_test.go`
+
+**Interfaces:**
+- Consumes: `gojwt.WithIssuer(iss string) gojwt.ParserOption` (golang-jwt v5, already a transitive import via `gojwt "github.com/golang-jwt/jwt/v5"` in `token.go`), `gojwt.ParseWithClaims(tokenString string, claims Claims, keyFunc Keyfunc, options ...ParserOption) (*Token, error)` (already called in `Verify`, currently with zero `ParserOption`s).
+- Produces: `func WithExpectedIssuer(issuer string) Option` — new public symbol other code/tests can call directly, e.g. `jwt.Verify[T](token, secret, jwt.WithExpectedIssuer("myapp"))`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add the following four test functions to `go-auth/jwt/token_test.go`. Insert them right after `TestWithIssuerEmptyIgnored` (currently ends at line 381, right before `func TestWithSigningMethodNilIgnored` at line 383):
+
+```go
+func TestVerifyWithExpectedIssuerMatch(t *testing.T) {
+	claims := UserClaims{UserUUID: "user-issuer-match"}
+
+	token, err := Sign(claims, testSecret, WithExpiration(time.Hour), WithIssuer("myapp"))
+	require.NoError(t, err)
+
+	parsed, err := Verify[UserClaims](token, testSecret, WithExpectedIssuer("myapp"))
+	require.NoError(t, err)
+	assert.Equal(t, "myapp", parsed.Issuer)
+	assert.Equal(t, "user-issuer-match", parsed.UserUUID)
+}
+
+func TestVerifyWithExpectedIssuerMismatch(t *testing.T) {
+	claims := UserClaims{UserUUID: "user-issuer-mismatch"}
+
+	token, err := Sign(claims, testSecret, WithExpiration(time.Hour), WithIssuer("other-app"))
+	require.NoError(t, err)
+
+	_, err = Verify[UserClaims](token, testSecret, WithExpectedIssuer("myapp"))
+	require.Error(t, err)
+
+	code, _ := goerror.Extract(err)
+	assert.Equal(t, autherror.CodeTokenInvalid, code)
+}
+
+func TestVerifyWithExpectedIssuerMissingClaim(t *testing.T) {
+	// Token signed without WithIssuer carries no iss claim at all.
+	claims := UserClaims{UserUUID: "user-issuer-missing"}
+
+	token, err := Sign(claims, testSecret, WithExpiration(time.Hour))
+	require.NoError(t, err)
+
+	_, err = Verify[UserClaims](token, testSecret, WithExpectedIssuer("myapp"))
+	require.Error(t, err)
+
+	code, _ := goerror.Extract(err)
+	assert.Equal(t, autherror.CodeTokenInvalid, code)
+}
+
+func TestVerifyWithoutExpectedIssuerIgnoresTokenIssuer(t *testing.T) {
+	// Backward-compat regression: without WithExpectedIssuer, Verify must not
+	// enforce any issuer check, regardless of what issuer the token carries.
+	claims := UserClaims{UserUUID: "user-issuer-unchecked"}
+
+	token, err := Sign(claims, testSecret, WithExpiration(time.Hour), WithIssuer("some-app"))
+	require.NoError(t, err)
+
+	parsed, err := Verify[UserClaims](token, testSecret)
+	require.NoError(t, err)
+	assert.Equal(t, "some-app", parsed.Issuer)
+	assert.Equal(t, "user-issuer-unchecked", parsed.UserUUID)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./go-auth/jwt/... -run 'TestVerifyWithExpectedIssuer|TestVerifyWithoutExpectedIssuer' -v`
+Expected: compile failure — `undefined: WithExpectedIssuer` (the option doesn't exist yet).
+
+- [ ] **Step 3: Add `expectedIssuer` field and `WithExpectedIssuer` option**
+
+In `go-auth/jwt/options.go`, update the `config` struct (currently lines 49-54):
+
+```go
+// config 存储 JWT 配置选项。
+// expiration 为指针类型以区分"未显式设置"（nil，使用默认 2h）
+// 与"显式覆盖"（非 nil，覆盖 Claims 自带值）。
+// ignoreClaimsExpiration 仅在 Refresh 路径为 true，表示忽略 Claims 自带的
+// ExpiresAt，强制以默认或显式 expiration 重新设定（Refresh 语义：新 Token
+// 使用新的过期时间，不复用旧 Token 的剩余有效期）。
+// issuer 仅在 Sign 时生效（设置签发的 Issuer）；expectedIssuer 仅在 Verify
+// 时生效（校验 Token 的 Issuer 必须等于该值）——两者语义独立，互不影响。
+type config struct {
+	expiration             *time.Duration
+	issuer                 string
+	expectedIssuer         string
+	signingMethod          gojwt.SigningMethod
+	ignoreClaimsExpiration bool
+}
+```
+
+Replace the existing `WithIssuer` function (currently lines 70-77) with:
+
+```go
+// WithIssuer 设置 JWT 签发者。空字符串忽略。
+// 仅在 Sign 时生效，用于设置签发 Token 的 Issuer；Verify 不会读取此选项，
+// 传给 Verify 时会被静默忽略。若需要在 Verify 时校验 Token 的 issuer，使用
+// WithExpectedIssuer。
+func WithIssuer(issuer string) Option {
+	return func(c *config) {
+		if issuer != "" {
+			c.issuer = issuer
+		}
+	}
+}
+
+// WithExpectedIssuer 要求 Verify 校验 Token 的 issuer（iss claim）必须等于
+// 给定值。空字符串忽略。
+// 仅在 Verify 时生效；Sign 不会读取此选项。Token 的 iss claim 缺失或与给定
+// 值不匹配时，Verify 返回 autherror.ErrTokenInvalid。与 WithIssuer 语义独立
+// （WithIssuer 只影响 Sign），两者可同时传给 Refresh 而不互相干扰。
+func WithExpectedIssuer(issuer string) Option {
+	return func(c *config) {
+		if issuer != "" {
+			c.expectedIssuer = issuer
+		}
+	}
+}
+```
+
+- [ ] **Step 4: Wire `expectedIssuer` into `Verify`**
+
+In `go-auth/jwt/token.go`, the `Verify` function currently builds `token, err := gojwt.ParseWithClaims(tokenStr, claims, func(tok *gojwt.Token) (any, error) { ... })` with no trailing `ParserOption`s (lines 74-86). Change it to compute parser options first and pass them through:
+
+```go
+	var parserOpts []gojwt.ParserOption
+	if cfg.expectedIssuer != "" {
+		parserOpts = append(parserOpts, gojwt.WithIssuer(cfg.expectedIssuer))
+	}
+
+	var keyTypeErr error
+	token, err := gojwt.ParseWithClaims(tokenStr, claims, func(tok *gojwt.Token) (any, error) {
+		// 验证签名算法，防止算法混淆攻击（如 RS256→HS256）。
+		// 必须先于密钥类型校验执行：算法不匹配是安全防御，优先级高于
+		// 调用方的密钥类型配置错误（保持 CodeTokenInvalid 语义不变）。
+		if tok.Method != cfg.signingMethod {
+			return nil, fmt.Errorf("unexpected signing method: got %v, want %v", tok.Header["alg"], cfg.signingMethod.Alg())
+		}
+		if err := validateKeyType(cfg.signingMethod, secret, false); err != nil {
+			keyTypeErr = err
+			return nil, err
+		}
+		return secret, nil
+	}, parserOpts...)
+```
+
+This replaces only the `token, err := gojwt.ParseWithClaims(...)` call and the lines immediately before it (the `var keyTypeErr error` declaration moves above the new `parserOpts` block, everything else in `Verify` — the keyfunc body, the error handling after the call, the final type-assertion return — stays exactly as-is).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./go-auth/jwt/... -run 'TestVerifyWithExpectedIssuer|TestVerifyWithoutExpectedIssuer' -v`
+Expected: PASS (4/4).
+
+- [ ] **Step 6: Run the existing Refresh/Sign/Verify suite to confirm no regression**
+
+Run: `go test ./go-auth/jwt/... -count=1 -v`
+Expected: ALL PASS, including `TestRefreshWithIssuer` unchanged and still green, `TestSignWithIssuer`/`TestWithIssuerEmptyIgnored` unchanged and still green.
+
+- [ ] **Step 7: Add a package-doc usage example for discoverability**
+
+In `go-auth/jwt/options.go`, the package comment's usage block (lines 13-26) currently ends with the RS256 example. Append one more example line after the existing `claims, err := jwt.Verify[UserClaims](token, secret)` line (line 21) — insert it directly below that line, before the blank line that precedes the `Refresh` example:
+
+```go
+//	token, err := jwt.Sign(UserClaims{UserUUID: "123"}, secret, jwt.WithExpiration(time.Hour))
+//	claims, err := jwt.Verify[UserClaims](token, secret)
+//	claims, err := jwt.Verify[UserClaims](token, secret, jwt.WithExpectedIssuer("myapp")) // 校验 issuer
+//	newToken, err := jwt.Refresh[UserClaims](ctx, token, secret, revocationStore, jwt.WithExpiration(24*time.Hour))
+```
+
+- [ ] **Step 8: Full module validation**
+
+```bash
+gofmt -l go-auth/
+go vet ./go-auth/...
+golangci-lint run ./go-auth/...
+go test ./go-auth/... -count=1
+```
+
+Expected: `gofmt -l` no output; `go vet`/`golangci-lint`/`go test` all clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add go-auth/jwt/options.go go-auth/jwt/token.go go-auth/jwt/token_test.go
+git commit -m "fix(go-auth): enforce issuer validation in jwt.Verify via WithExpectedIssuer"
+```
+
+---
+
+## Self-Review Notes (checked while writing this plan)
+
+- **Spec coverage:** The design's three AC items (Verify path enforces issuer check / unit tests for mismatch / godoc clarifying Sign vs Verify behavior) are all covered by Task 1 Steps 3-4 (implementation), Step 1 (tests: match, mismatch, missing-claim, backward-compat regression), and Steps 3+7 (godoc on both `WithIssuer` and `WithExpectedIssuer`, plus a package-doc usage example).
+- **Refresh non-regression:** Step 6 explicitly runs the full `go-auth/jwt` suite including the pre-existing `TestRefreshWithIssuer`, which the design identified as the test most likely to break under a naive (single-option) implementation. Since this plan's `WithExpectedIssuer` is a distinct option that `Refresh` never sets internally, that test requires zero changes.
+- **Type consistency:** `WithExpectedIssuer(issuer string) Option` matches the existing `Option func(*config)` type and the calling convention used by every other `WithXxx` function in `options.go` (single string param, empty-string-ignored guard, matching the project's Functional Options Pattern rule in `.claude/rules/options-pattern.md` §2.2).
+- **No placeholders:** every step above contains literal code to write or literal commands to run.

--- a/docs/superpowers/specs/2026-09-02-jwt-verify-issuer-design.md
+++ b/docs/superpowers/specs/2026-09-02-jwt-verify-issuer-design.md
@@ -1,0 +1,74 @@
+# Design: Verify Issuer 校验（Issue #75）
+
+## Context
+
+`WithIssuer` 的 godoc 未说明它仅在 Sign 时生效；调用方若误以为
+`jwt.Verify(token, secret, jwt.WithIssuer("myapp"))` 会校验 Token 的 issuer
+是否等于 "myapp"，实际上该选项在 Verify 路径被静默忽略（`cfg.issuer` 只在
+`setClaimsDefaults` 里被使用，该函数只在 Sign 中调用）。跨服务共享同一签名
+密钥的场景下，如果开发者误以为传入 WithIssuer 就能限定 Verify 只接受特定
+issuer 的 Token，实际上任何 issuer 的 Token 都会通过校验，可能导致越权。
+
+## Goal
+
+在 Verify 中真正实现 issuer 校验，同时不破坏 `Refresh` 现有的
+`WithIssuer` 用法（`Refresh` 内部先 `Verify` 旧 token 再 `Sign` 新
+token，两步共用同一份 `opts`）。
+
+## 设计冲突与决策
+
+若直接让 `WithIssuer` 同时影响 Sign 与 Verify，`Refresh` 内部透传给
+`Verify` 的 opts 会把"调用方想设置到新 token 上的 issuer"误用于校验
+"旧 token 的 issuer"，导致合法的 Refresh（旧 token 无 issuer 或 issuer
+不同，只是想给新 token 设置新 issuer）被误判为不匹配而拒绝——现有测试
+`TestRefreshWithIssuer` 正是这个场景。
+
+**决策**：新增独立选项 `WithExpectedIssuer`，专用于 Verify 路径的校验；
+`WithIssuer` 保持现状（仅 Sign 时生效，只补文档说明）。两个选项语义不
+重叠，`Refresh` 无需任何特殊处理，现有测试不受影响。
+
+## API 变更
+
+`go-auth/jwt/options.go`：
+
+```go
+func WithExpectedIssuer(issuer string) Option {
+    return func(c *config) {
+        if issuer != "" {
+            c.expectedIssuer = issuer
+        }
+    }
+}
+```
+
+`config` 结构体新增 `expectedIssuer string` 字段。
+
+## 核心逻辑
+
+`go-auth/jwt/token.go` 的 `Verify`：调用 `gojwt.ParseWithClaims` 时，若
+`cfg.expectedIssuer != ""`，追加 `gojwt.WithIssuer(cfg.expectedIssuer)`
+作为 `gojwt.ParserOption`。校验失败（issuer 不匹配或 token 缺失 `iss`
+claim）时走现有 `mapJWTError` 默认分支，返回 `autherror.ErrTokenInvalid`
+（不新增错误码）。
+
+## godoc 更新
+
+- `WithIssuer`：明确"仅在 Sign 时生效，用于设置签发者；Verify 不读取此
+  选项。校验 issuer 请用 `WithExpectedIssuer`"
+- `WithExpectedIssuer`：明确"仅在 Verify 时生效，要求 token 的 `iss`
+  claim 必须等于给定值；不匹配或缺失均返回错误。Sign 不读取此选项"
+
+## 测试
+
+`go-auth/jwt/token_test.go` 新增：
+- issuer 匹配 → Verify 成功
+- issuer 不匹配 → Verify 返回 `autherror.CodeTokenInvalid`
+- token 缺失 `iss` claim 但设了 `WithExpectedIssuer` → Verify 返回错误
+- 不设置 `WithExpectedIssuer` 时，Verify 忽略 token 的 `iss`（向后兼容
+  回归测试）
+
+`TestRefreshWithIssuer` 不改动，确认仍然通过。
+
+## 范围外
+
+- 不改动 `Refresh` 的内部逻辑——它不会用到新选项，除非调用方显式传入。

--- a/example/handler/auth_jwt.go
+++ b/example/handler/auth_jwt.go
@@ -115,7 +115,7 @@ func jwtVerifyHandler(ctx context.Context, c *app.RequestContext) {
 		return
 	}
 
-	claims, err := jwt.Verify[AppClaims](req.Token, jwtSecret)
+	claims, err := jwt.Verify[AppClaims](req.Token, jwtSecret, jwt.WithExpectedIssuer(jwtIssuer))
 	if err != nil {
 		hertzresp.Error(ctx, c, err, "verify token failed")
 		return

--- a/go-auth/jwt/options.go
+++ b/go-auth/jwt/options.go
@@ -19,6 +19,7 @@
 //
 //	token, err := jwt.Sign(UserClaims{UserUUID: "123"}, secret, jwt.WithExpiration(time.Hour))
 //	claims, err := jwt.Verify[UserClaims](token, secret)
+//	claims, err := jwt.Verify[UserClaims](token, secret, jwt.WithExpectedIssuer("myapp")) // 校验 issuer
 //	newToken, err := jwt.Refresh[UserClaims](ctx, token, secret, revocationStore, jwt.WithExpiration(24*time.Hour))
 //
 //	// 非对称算法示例（RS256）：
@@ -46,9 +47,12 @@ const (
 // ignoreClaimsExpiration 仅在 Refresh 路径为 true，表示忽略 Claims 自带的
 // ExpiresAt，强制以默认或显式 expiration 重新设定（Refresh 语义：新 Token
 // 使用新的过期时间，不复用旧 Token 的剩余有效期）。
+// issuer 仅在 Sign 时生效（设置签发的 Issuer）；expectedIssuer 仅在 Verify
+// 时生效（校验 Token 的 Issuer 必须等于该值）——两者语义独立，互不影响。
 type config struct {
 	expiration             *time.Duration
 	issuer                 string
+	expectedIssuer         string
 	signingMethod          gojwt.SigningMethod
 	ignoreClaimsExpiration bool
 }
@@ -68,10 +72,26 @@ func WithExpiration(d time.Duration) Option {
 }
 
 // WithIssuer 设置 JWT 签发者。空字符串忽略。
+// 仅在 Sign 时生效，用于设置签发 Token 的 Issuer；Verify 不会读取此选项，
+// 传给 Verify 时会被静默忽略。若需要在 Verify 时校验 Token 的 issuer，使用
+// WithExpectedIssuer。
 func WithIssuer(issuer string) Option {
 	return func(c *config) {
 		if issuer != "" {
 			c.issuer = issuer
+		}
+	}
+}
+
+// WithExpectedIssuer 要求 Verify 校验 Token 的 issuer（iss claim）必须等于
+// 给定值。空字符串忽略。
+// 仅在 Verify 时生效；Sign 不会读取此选项。Token 的 iss claim 缺失或与给定
+// 值不匹配时，Verify 返回 autherror.ErrTokenInvalid。与 WithIssuer 语义独立
+// （WithIssuer 只影响 Sign），两者可同时传给 Refresh 而不互相干扰。
+func WithExpectedIssuer(issuer string) Option {
+	return func(c *config) {
+		if issuer != "" {
+			c.expectedIssuer = issuer
 		}
 	}
 }

--- a/go-auth/jwt/options.go
+++ b/go-auth/jwt/options.go
@@ -84,7 +84,8 @@ func WithIssuer(issuer string) Option {
 }
 
 // WithExpectedIssuer 要求 Verify 校验 Token 的 issuer（iss claim）必须等于
-// 给定值。空字符串忽略。
+// 给定值。空字符串忽略（即不做任何 issuer 校验，请确保配置项非空，否则本
+// 选项等同未启用）。
 // 仅在 Verify 时生效；Sign 不会读取此选项。Token 的 iss claim 缺失或与给定
 // 值不匹配时，Verify 返回 autherror.ErrTokenInvalid。与 WithIssuer 语义独立
 // （WithIssuer 只影响 Sign），两者可同时传给 Refresh 而不互相干扰。

--- a/go-auth/jwt/token.go
+++ b/go-auth/jwt/token.go
@@ -70,6 +70,11 @@ func Verify[T any](tokenStr string, secret any, opts ...Option) (*T, error) {
 			Errorf("claims type %T does not implement jwt.Claims", zero)
 	}
 
+	var parserOpts []gojwt.ParserOption
+	if cfg.expectedIssuer != "" {
+		parserOpts = append(parserOpts, gojwt.WithIssuer(cfg.expectedIssuer))
+	}
+
 	var keyTypeErr error
 	token, err := gojwt.ParseWithClaims(tokenStr, claims, func(tok *gojwt.Token) (any, error) {
 		// 验证签名算法，防止算法混淆攻击（如 RS256→HS256）。
@@ -83,7 +88,7 @@ func Verify[T any](tokenStr string, secret any, opts ...Option) (*T, error) {
 			return nil, err
 		}
 		return secret, nil
-	})
+	}, parserOpts...)
 	if err != nil {
 		if keyTypeErr != nil {
 			return nil, keyTypeErr

--- a/go-auth/jwt/token_test.go
+++ b/go-auth/jwt/token_test.go
@@ -380,6 +380,59 @@ func TestWithIssuerEmptyIgnored(t *testing.T) {
 	assert.Empty(t, parsed.Issuer)
 }
 
+func TestVerifyWithExpectedIssuerMatch(t *testing.T) {
+	claims := UserClaims{UserUUID: "user-issuer-match"}
+
+	token, err := Sign(claims, testSecret, WithExpiration(time.Hour), WithIssuer("myapp"))
+	require.NoError(t, err)
+
+	parsed, err := Verify[UserClaims](token, testSecret, WithExpectedIssuer("myapp"))
+	require.NoError(t, err)
+	assert.Equal(t, "myapp", parsed.Issuer)
+	assert.Equal(t, "user-issuer-match", parsed.UserUUID)
+}
+
+func TestVerifyWithExpectedIssuerMismatch(t *testing.T) {
+	claims := UserClaims{UserUUID: "user-issuer-mismatch"}
+
+	token, err := Sign(claims, testSecret, WithExpiration(time.Hour), WithIssuer("other-app"))
+	require.NoError(t, err)
+
+	_, err = Verify[UserClaims](token, testSecret, WithExpectedIssuer("myapp"))
+	require.Error(t, err)
+
+	code, _ := goerror.Extract(err)
+	assert.Equal(t, autherror.CodeTokenInvalid, code)
+}
+
+func TestVerifyWithExpectedIssuerMissingClaim(t *testing.T) {
+	// Token signed without WithIssuer carries no iss claim at all.
+	claims := UserClaims{UserUUID: "user-issuer-missing"}
+
+	token, err := Sign(claims, testSecret, WithExpiration(time.Hour))
+	require.NoError(t, err)
+
+	_, err = Verify[UserClaims](token, testSecret, WithExpectedIssuer("myapp"))
+	require.Error(t, err)
+
+	code, _ := goerror.Extract(err)
+	assert.Equal(t, autherror.CodeTokenInvalid, code)
+}
+
+func TestVerifyWithoutExpectedIssuerIgnoresTokenIssuer(t *testing.T) {
+	// Backward-compat regression: without WithExpectedIssuer, Verify must not
+	// enforce any issuer check, regardless of what issuer the token carries.
+	claims := UserClaims{UserUUID: "user-issuer-unchecked"}
+
+	token, err := Sign(claims, testSecret, WithExpiration(time.Hour), WithIssuer("some-app"))
+	require.NoError(t, err)
+
+	parsed, err := Verify[UserClaims](token, testSecret)
+	require.NoError(t, err)
+	assert.Equal(t, "some-app", parsed.Issuer)
+	assert.Equal(t, "user-issuer-unchecked", parsed.UserUUID)
+}
+
 func TestWithSigningMethodNilIgnored(t *testing.T) {
 	claims := UserClaims{UserUUID: "user-nil-method"}
 

--- a/go-auth/jwt/token_test.go
+++ b/go-auth/jwt/token_test.go
@@ -229,6 +229,48 @@ func TestRefreshWithIssuer(t *testing.T) {
 	assert.Equal(t, "user-issuer-refresh", parsed.UserUUID)
 }
 
+func TestRefreshWithIssuerAndExpectedIssuerCoexist(t *testing.T) {
+	// WithIssuer（作用于 Refresh 内部 Sign）与 WithExpectedIssuer（作用于
+	// Refresh 内部 Verify）语义独立：同时传入不应互相干扰。
+	claims := UserClaims{UserUUID: "user-issuer-coexist"}
+
+	oldToken, err := Sign(claims, testSecret, WithExpiration(time.Hour), WithIssuer("old-app"))
+	require.NoError(t, err)
+
+	newToken, err := Refresh[UserClaims](context.Background(), oldToken, testSecret, newFakeRevocationStore(),
+		WithExpectedIssuer("old-app"),
+		WithIssuer("new-app"),
+	)
+	require.NoError(t, err)
+
+	parsed, err := Verify[UserClaims](newToken, testSecret)
+	require.NoError(t, err)
+	assert.Equal(t, "new-app", parsed.Issuer)
+	assert.Equal(t, "user-issuer-coexist", parsed.UserUUID)
+}
+
+func TestRefreshWithExpectedIssuerMismatchFails(t *testing.T) {
+	// WithExpectedIssuer 校验的是旧 Token 的 issuer；不匹配时 Refresh 内部
+	// Verify 先失败。Refresh 用 oops.With("jwt.Refresh").Code(CodeJWTRefreshFailed).Wrap(err)
+	// 包装该错误，但 goerror.Extract 沿错误链返回最内层（原始）错误的 Code，
+	// 而不是外层 Wrap 时设置的 Code——因此顶层观测到的仍是 Verify 产生的
+	// CodeTokenInvalid，而非 CodeJWTRefreshFailed。此行为此前未被任何测试
+	// 验证过，本用例把它钉住。
+	claims := UserClaims{UserUUID: "user-issuer-coexist-mismatch"}
+
+	oldToken, err := Sign(claims, testSecret, WithExpiration(time.Hour), WithIssuer("old-app"))
+	require.NoError(t, err)
+
+	_, err = Refresh[UserClaims](context.Background(), oldToken, testSecret, newFakeRevocationStore(),
+		WithExpectedIssuer("wrong-app"),
+		WithIssuer("new-app"),
+	)
+	require.Error(t, err)
+
+	code, _ := goerror.Extract(err)
+	assert.Equal(t, autherror.CodeTokenInvalid, code)
+}
+
 func TestRefreshCarriesDefaultExpiration(t *testing.T) {
 	// Refresh 不传 WithExpiration 时，新 Token 也应使用默认 2h。
 	claims := UserClaims{UserUUID: "user-refresh-default"}


### PR DESCRIPTION
## Summary

Closes #75

`jwt.Verify` previously silently ignored `WithIssuer` — callers who passed `jwt.Verify(token, secret, jwt.WithIssuer("myapp"))` expecting the verifier to reject tokens issued for a different service got no such check (`WithIssuer` only ever affected `Sign`). In a deployment where multiple services share one signing secret, this is a privilege-escalation risk: any service's tokens validate everywhere.

## Changes

- **New option** `jwt.WithExpectedIssuer(issuer string) Option` — enforces that a verified token's `iss` claim matches the given value. Both a mismatched issuer and a missing `iss` claim return an error.
- `WithIssuer` is **unchanged** (still Sign-only) — this was a deliberate design decision, not a compromise: `jwt.Refresh` internally calls `Verify` then `Sign` reusing the same `opts`, so a single option affecting both would have broken legitimate "re-issue under a new issuer" refresh flows.
- Godoc on both options now explicitly states which of Sign/Verify reads which field.
- `example/handler/auth_jwt.go`'s verify handler updated to demonstrate `WithExpectedIssuer`.

## Tests

New tests in `go-auth/jwt/token_test.go`:
- issuer match → success
- issuer mismatch → error (`autherror.CodeTokenInvalid`)
- missing `iss` claim with `WithExpectedIssuer` set → error
- backward-compat regression: `Verify` without `WithExpectedIssuer` ignores the token's issuer entirely (unchanged existing behavior)
- `Refresh` combining `WithIssuer("new-app")` (sets the new token's issuer) + `WithExpectedIssuer("old-app")` (validates the old token) → succeeds, proving the two options don't interfere
- same combination with a mismatched `WithExpectedIssuer` → `Refresh` returns an error

`TestRefreshWithIssuer` (pre-existing) is unmodified and still passes.

## Review process

Went through subagent-driven-development (1 task, clean first pass) plus a security-focused final whole-branch review. The review confirmed via upstream `golang-jwt`/`samber/oops` source that the issuer-check placement (after signature verification, before claims are returned) has no bypass path, and found no Critical issues. One fix round addressed 1 Important + 2 Minor findings (a missing Refresh-coexistence test, an undocumented fail-open on the empty-string guard, and the example not demonstrating the new option) — verified by a scoped re-review, all addressed with no new breakage.

**Follow-up, deliberately out of scope for this PR:** #85 — `go-framework`'s Hertz `JWTAuth` middleware hardcodes `gojwt.Verify[T](token, secret)` with no options passthrough, so the primary consumer of this package can't adopt `WithExpectedIssuer` yet. This is a separate, larger API-surface change (middleware option design) that deserves its own review.

## Test plan

- [x] `go build ./go-common/... ./go-auth/... ./go-middleware/... ./go-framework/... ./example/...`
- [x] `go vet` (same set)
- [x] `gofmt -l` — clean
- [x] `golangci-lint run ./go-auth/...` — 0 issues
- [x] `go test ./go-common/... ./go-auth/... ./go-middleware/... ./go-framework/... -count=1` — all packages pass


Closes #75