### PR TITLE
docs(go-auth): fix dependency graph in doc.go to reflect DAG topology

### DIFF
--- a/go-auth/doc.go
+++ b/go-auth/doc.go
@@ -8,5 +8,9 @@
 //
 // 依赖关系：
 //
-//	go-common → go-auth → go-middleware → go-framework
+// 真实拓扑是 DAG，而非线性链：go-framework 与 go-middleware 是互不依赖的兄弟模块，
+// 二者均直接依赖 go-auth + go-common。
+//
+//	go-common → go-auth ─┬→ go-middleware
+//	                      └→ go-framework
 package auth


### PR DESCRIPTION
## Summary
- `go-auth/doc.go` 的依赖关系图此前写成线性链 `go-common → go-auth → go-middleware → go-framework`，与 CLAUDE.md / `.claude/rules/go.md` 描述的真实 DAG 拓扑矛盾（go-framework 与 go-middleware 为互不依赖的兄弟模块，均直接依赖 go-auth + go-common）。
- 更新 doc.go 依赖图注释为 DAG 描述，消除歧义，避免误导后续开发在两者之间引入循环依赖。

## Test plan
- [x] `gofmt -l go-auth/doc.go` 无输出
- [x] `go build ./go-auth/...` 通过

Closes #77