### PR TITLE
docs(auth): document single-level RegisteredClaims embedding limit (#80)

### DIFF
--- a/go-auth/jwt/options.go
+++ b/go-auth/jwt/options.go
@@ -31,6 +31,20 @@
 //	// 非对称算法示例（RS256）：
 //	token, err := jwt.Sign(UserClaims{UserUUID: "123"}, rsaPrivateKey, jwt.WithSigningMethod(gojwt.SigningMethodRS256))
 //	claims, err := jwt.Verify[UserClaims](token, rsaPublicKey, jwt.WithSigningMethod(gojwt.SigningMethodRS256))
+//
+// 关于 Claims 中 RegisteredClaims 的嵌入方式（重要限制）：
+// 默认过期时间/Issuer 填充（见 Sign）以及 ExtractJTI/Refresh 的 JTI 轮换
+// 逻辑，都依赖通过反射从 Claims 中找到嵌入的 gojwt.RegisteredClaims。
+// 该反射查找只支持 RegisteredClaims 被**直接、单层**嵌入到 Claims 顶层
+// 结构体（如上面 UserClaims 示例）。以下两种写法都不受支持，会被**静默**
+// 忽略（不返回错误、不记录日志），效果等同于 Claims 未携带
+// RegisteredClaims：
+//   - 使用 gojwt.MapClaims 作为 Claims 类型；
+//   - RegisteredClaims 被间接/多层嵌入，例如 Claims 嵌入了另一个中间
+//     结构体，RegisteredClaims 又嵌入在该中间结构体内部，而非直接嵌入
+//     Claims 本身。
+//
+// 详见 extractRegisteredClaims/extractEmbeddedRegisteredClaims 的实现注释。
 package jwt
 
 import (

--- a/go-auth/jwt/token.go
+++ b/go-auth/jwt/token.go
@@ -321,9 +321,12 @@ func setClaimsDefaults(claims gojwt.Claims, cfg config) {
 }
 
 // ExtractJTI 从已验证的 Claims 中提取 JWT ID（jti）。
-// claims 通常是 Verify 返回的 *T 指针（或任何实现 jwt.Claims 且嵌入了
-// gojwt.RegisteredClaims 的结构体指针）。未找到 RegisteredClaims 或
-// ID 为空时返回 ("", false)。
+// claims 通常是 Verify 返回的 *T 指针（或任何实现 jwt.Claims 且直接
+// （单层）嵌入了 gojwt.RegisteredClaims 的结构体指针）。未找到
+// RegisteredClaims 或 ID 为空时返回 ("", false)。
+// 注意：gojwt.MapClaims 以及 RegisteredClaims 被多层/间接嵌入的情况
+// 都无法被识别，会静默返回 ("", false)，详见 extractRegisteredClaims
+// 的文档。
 func ExtractJTI(claims any) (string, bool) {
 	jwtClaims, ok := claims.(gojwt.Claims)
 	if !ok {
@@ -342,7 +345,20 @@ func ExtractJTI(claims any) (string, bool) {
 // 支持以下类型：
 //   - *gojwt.RegisteredClaims（直接返回）
 //   - *gojwt.MapClaims（不支持，返回 nil）
-//   - 任何嵌入了 RegisteredClaims 的结构体指针（通过反射提取）
+//   - 任何直接（单层）嵌入了 RegisteredClaims 的结构体指针（通过反射提取）
+//
+// 限制（重要，扩展 Claims 结构体时务必注意）：仅支持 RegisteredClaims 被
+// 直接嵌入到顶层 Claims 结构体这一种形态。以下两种情况都会被静默忽略、
+// 返回 nil，不会有任何错误或日志提示：
+//  1. gojwt.MapClaims（不支持反射提取字段）；
+//  2. RegisteredClaims 被间接/多层嵌入，例如顶层结构体嵌入了另一个中间
+//     结构体，RegisteredClaims 又嵌入在该中间结构体内部（见
+//     extractEmbeddedRegisteredClaims 的字段遍历只扫描直接字段，不递归）。
+//
+// 返回 nil 时，setClaimsDefaults 中默认过期时间/Issuer 的填充逻辑会被
+// 静默跳过（不报错），ExtractJTI 也会返回 ("", false)。为避免这个隐式
+// 契约“咬人”，自定义 Claims 类型时应确保 RegisteredClaims 直接嵌入在
+// 最外层结构体中。
 func extractRegisteredClaims(claims gojwt.Claims) *gojwt.RegisteredClaims {
 	if claims == nil {
 		return nil
@@ -360,6 +376,9 @@ func extractRegisteredClaims(claims gojwt.Claims) *gojwt.RegisteredClaims {
 }
 
 // extractEmbeddedRegisteredClaims 通过反射查找嵌入的 RegisteredClaims 字段。
+// 仅遍历顶层结构体的直接（单层）字段，不递归查找嵌套结构体内部的字段；
+// 因此 RegisteredClaims 若被间接嵌入（嵌入在某个中间结构体里，而非直接
+// 嵌入到传入的顶层结构体），本函数会找不到该字段并静默返回 nil。
 func extractEmbeddedRegisteredClaims(claims gojwt.Claims) *gojwt.RegisteredClaims {
 	v := reflect.ValueOf(claims)
 	if v.Kind() == reflect.Pointer {

--- a/go-auth/jwt/token_test.go
+++ b/go-auth/jwt/token_test.go
@@ -535,6 +535,33 @@ func TestExtractJTI(t *testing.T) {
 		assert.False(t, ok)
 		assert.Empty(t, jti)
 	})
+
+	t.Run("multi-level nested embedding not supported (documented limitation)", func(t *testing.T) {
+		// RegisteredClaims 被间接嵌入：nestedJTIClaims 嵌入了 nestedRegisteredClaims，
+		// 而 RegisteredClaims 又嵌入在 nestedRegisteredClaims 内部，并非直接嵌入
+		// nestedJTIClaims 本身。extractEmbeddedRegisteredClaims 只扫描直接字段，
+		// 不递归，因此这里应静默返回 ("", false)，锁定该已文档化的限制行为。
+		claims := &nestedJTIClaims{
+			nestedRegisteredClaims: nestedRegisteredClaims{
+				RegisteredClaims: gojwt.RegisteredClaims{ID: "jti-nested"},
+			},
+		}
+		jti, ok := ExtractJTI(claims)
+		assert.False(t, ok)
+		assert.Empty(t, jti)
+	})
+}
+
+// nestedRegisteredClaims 是一个中间结构体，直接嵌入 RegisteredClaims。
+type nestedRegisteredClaims struct {
+	gojwt.RegisteredClaims
+}
+
+// nestedJTIClaims 通过中间结构体间接（两层）嵌入 RegisteredClaims，
+// 而非直接嵌入到顶层结构体——用于验证 extractEmbeddedRegisteredClaims
+// 不支持多层嵌入的文档化限制。
+type nestedJTIClaims struct {
+	nestedRegisteredClaims
 }
 
 // ── 非对称算法（RS256/ES256）真实签发/验证 ──


### PR DESCRIPTION
## Summary
- `extractRegisteredClaims`/`extractEmbeddedRegisteredClaims` only scan direct fields of the top-level Claims struct via reflection (no recursion). `gojwt.MapClaims` and multi-level (indirect) embedding of `RegisteredClaims` both silently return nil, silently skipping default expiration/Issuer handling.
- Documented this limitation on the affected functions, `ExtractJTI`, and the package doc comment.
- Added a regression test locking in the documented behavior for the multi-level-nested-embedding case.
- Evaluated adding a warning log for the silent-nil case; decided against it since `go-auth/jwt` has no logger dependency injected into `Sign`/`Verify`/`Refresh`, and wiring one in would be a larger API change than this docs-only issue warrants.

Closes #80

## Test plan
- [x] `gofmt -l` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -count=1` passes (go-auth module)
- [x] `golangci-lint run --timeout=5m ./...` (go-auth module) — 0 issues