### PR TITLE
feat(go-framework): add TLS-by-default + Functional Options to observability providers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ The 5-module → 3-library split (2026-06-23) is **complete**. ncgo generated pr
 | D4 | Release strategy | **Independent versioning** | ✅ active |
 | D5 | Old modules | **Fully removed**, all code migrated to 3 libraries | ✅ done |
 | D6 | Error code ownership | **Owning modules** define their codes; `go-common/error` = mechanism + band boundaries + HTTP registry | ✅ active |
+| D7 | Observability OTLP TLS default | **Default TLS** (system root cert pool); `ObservabilityConfig.Insecure=true` opts back into plaintext (#96) | ✅ active |
 
 ## Error Code Ranges
 

--- a/docs/superpowers/plans/2026-09-03-observability-provider-options.md
+++ b/docs/superpowers/plans/2026-09-03-observability-provider-options.md
@@ -1,0 +1,913 @@
+# Observability Provider Options Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give `NewProvider` in `go-framework/hertz/observability` and `go-framework/kitex/observability` a Functional-Options surface (custom exporter/sampler/propagator/TLS) and flip the default OTLP gRPC transport from hardcoded plaintext to TLS-by-default, closing Issue #96.
+
+**Architecture:** Add a package-local `providerOptions` struct + `Option` type to each of the two `observability` packages (parallel, not shared — matches existing duplication style between hertz/kitex). `NewProvider` gains a trailing `opts ...Option` parameter (backward compatible). `config.ObservabilityConfig` gains an `Insecure bool` field. Exporter TLS credential selection follows a 3-way priority: custom `*tls.Config` (via `WithTLSConfig`) > `cfg.Insecure` (plaintext) > default TLS with system root cert pool.
+
+**Tech Stack:** Go 1.25 workspace mode, OpenTelemetry SDK v1.44.0 (`otlptracegrpc`, `otlpmetricgrpc`), `google.golang.org/grpc/credentials`, testify, `go.opentelemetry.io/otel/sdk/trace/tracetest` (in-memory exporter for tests).
+
+**Spec:** `docs/superpowers/specs/2026-09-03-observability-provider-options-design.md`
+
+## Global Constraints
+
+- `NewProvider` signature change MUST stay backward compatible: `opts ...Option` is a trailing variadic parameter; existing two-arg call sites (`NewProvider(ctx, cfg)`) must keep compiling unchanged.
+- `config.ObservabilityConfig.Insecure` zero value is `false` → **default behavior changes from plaintext to TLS**. This is an intentional, user-approved behavior change; document it, don't hide it.
+- `WithTLSConfig` takes priority over `cfg.Insecure` when both given.
+- Do NOT touch `otel.SetTracerProvider` / `otel.SetMeterProvider` / `otel.SetTextMapPropagator` global-setting behavior, and do NOT touch any downstream `otel.GetTracerProvider()` / `otel.GetMeterProvider()` / `otel.GetTextMapPropagator()` call sites in `tracer.go` / `client.go` / `suite.go` / `grpc_metadata.go` — out of scope per design doc.
+- Do NOT add certificate file path parsing — `WithTLSConfig` only accepts an already-built `*tls.Config`.
+- All exported symbols need godoc comments starting with the symbol name (`.claude/rules/go.md` § 8.3); errors must be checked or explicitly discarded with `_ =` (§ 8.4); use `any` not `interface{}` (§ 8.5).
+- Reuse existing error constructors `frameworkerror.ErrObsTraceExport` / `frameworkerror.ErrObsMetricExport` (codes 20603/20604) — no new error codes.
+- Existing kitex `TracerOption`/`tracerConfig` (in `suite.go`) is a separate, unrelated type system — do not touch it, do not let names collide with the new `Option`/`providerOptions`.
+
+---
+
+### Task 1: Add `Insecure` field to `config.ObservabilityConfig`
+
+**Files:**
+- Modify: `go-framework/config/observability.go`
+- Test: `go-framework/config/observability_test.go`
+
+**Interfaces:**
+- Produces: `config.ObservabilityConfig.Insecure bool` field, consumed by Task 2 and Task 3 (`NewProvider` in hertz/kitex).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `go-framework/config/observability_test.go` (new test function, keep existing ones untouched):
+
+```go
+func TestObservabilityConfig_InsecureDefaultsToFalse(t *testing.T) {
+	c := ObservabilityConfig{}
+	assert.False(t, c.Insecure, "Insecure 零值应为 false（默认走 TLS）")
+}
+
+func TestObservabilityConfig_InsecureExplicitTrue(t *testing.T) {
+	c := ObservabilityConfig{Insecure: true}
+	assert.True(t, c.Insecure)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./go-framework/config/... -run TestObservabilityConfig_Insecure -v`
+Expected: FAIL with `c.Insecure undefined (type ObservabilityConfig has no field or method Insecure)`
+
+- [ ] **Step 3: Add the field**
+
+In `go-framework/config/observability.go`, add after the `EnableGRPCMetadata` field (keep struct field order: append at end):
+
+```go
+	// Insecure 是否允许 OTLP gRPC exporter 使用明文传输（默认 false，即默认走 TLS）。
+	// 零值 false = 默认使用系统根证书池建立 TLS 连接；设为 true 才走明文。
+	// 行为变更提示：升级前版本硬编码明文传输，升级后默认改为 TLS——
+	// 如果你的 collector 未启用 TLS，需要显式设置 insecure: true。
+	Insecure bool `json:"insecure" yaml:"insecure"`
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./go-framework/config/... -v`
+Expected: PASS (all `TestObservabilityConfig_*` tests green, including the two new ones and the pre-existing `TestObservabilityConfig_Full` which doesn't set `Insecure` and must still pass since zero value is fine there)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add go-framework/config/observability.go go-framework/config/observability_test.go
+git commit -m "feat(config): add Insecure field to ObservabilityConfig (default false = TLS)"
+```
+
+---
+
+### Task 2: Hertz `observability` package — Options + secure-by-default `NewProvider`
+
+**Files:**
+- Create: `go-framework/hertz/observability/options.go`
+- Modify: `go-framework/hertz/observability/provider.go`
+- Test: `go-framework/hertz/observability/provider_test.go`
+
+**Interfaces:**
+- Consumes: `config.ObservabilityConfig.Insecure` (Task 1)
+- Produces:
+  - `type Option func(*providerOptions)`
+  - `func WithTraceExporter(exp sdktrace.SpanExporter) Option`
+  - `func WithMetricExporter(exp sdkmetric.Exporter) Option`
+  - `func WithSampler(sampler sdktrace.Sampler) Option`
+  - `func WithPropagator(p propagation.TextMapPropagator) Option`
+  - `func WithTLSConfig(cfg *tls.Config) Option`
+  - `func NewProvider(ctx context.Context, cfg config.ObservabilityConfig, opts ...Option) (*Provider, error)` (signature change, backward compatible)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `go-framework/hertz/observability/provider_test.go` (new imports needed: `"go.opentelemetry.io/otel/sdk/trace/tracetest"`, add to the existing import block):
+
+```go
+func TestNewProvider_WithTraceExporter_UsesInjectedExporter(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	cfg := config.ObservabilityConfig{
+		Enabled:     true,
+		ServiceName: "test-svc",
+	}
+	p, err := NewProvider(context.Background(), cfg, WithTraceExporter(exp))
+	require.NoError(t, err)
+	require.NotNil(t, p)
+
+	_, span := p.tracer.Start(context.Background(), "test-span")
+	span.End()
+	require.NoError(t, p.Shutdown())
+
+	spans := exp.GetSpans()
+	require.Len(t, spans, 1)
+	assert.Equal(t, "test-span", spans[0].Name)
+}
+
+func TestNewProvider_DefaultsToTLS_NotInsecure(t *testing.T) {
+	// Endpoint 指向不存在的地址；默认走 TLS 时 grpc.NewClient 仍能成功构造
+	// （lazy connect），不应该出现 exporter 构造期错误。这里只验证
+	// NewProvider 在默认（Insecure 未设置）情况下不会因为强制走 TLS 而
+	// 在构造阶段直接报错。
+	cfg := config.ObservabilityConfig{
+		Enabled:     true,
+		Endpoint:    "127.0.0.1:1",
+		ServiceName: "test-svc",
+	}
+	p, err := NewProvider(context.Background(), cfg)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	require.NoError(t, p.Shutdown())
+}
+
+func TestNewProvider_InsecureTrue_SkipsTLS(t *testing.T) {
+	cfg := config.ObservabilityConfig{
+		Enabled:     true,
+		Endpoint:    "127.0.0.1:1",
+		ServiceName: "test-svc",
+		Insecure:    true,
+	}
+	p, err := NewProvider(context.Background(), cfg)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	require.NoError(t, p.Shutdown())
+}
+
+func TestNewProvider_WithTLSConfig_TakesPriorityOverInsecure(t *testing.T) {
+	cfg := config.ObservabilityConfig{
+		Enabled:     true,
+		Endpoint:    "127.0.0.1:1",
+		ServiceName: "test-svc",
+		Insecure:    true, // should be overridden by WithTLSConfig
+	}
+	p, err := NewProvider(context.Background(), cfg, WithTLSConfig(&tls.Config{MinVersion: tls.VersionTLS12}))
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	require.NoError(t, p.Shutdown())
+}
+
+func TestNewProvider_WithSamplerAndPropagator(t *testing.T) {
+	cfg := config.ObservabilityConfig{
+		Enabled:     true,
+		ServiceName: "test-svc",
+	}
+	customPropagator := propagation.TraceContext{}
+	p, err := NewProvider(context.Background(), cfg,
+		WithSampler(sdktrace.AlwaysSample()),
+		WithPropagator(customPropagator),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	require.NoError(t, p.Shutdown())
+}
+```
+
+Add `"crypto/tls"` and `"go.opentelemetry.io/otel/sdk/trace/tracetest"` and `sdktrace "go.opentelemetry.io/otel/sdk/trace"` and `"go.opentelemetry.io/otel/propagation"` to the test file's import block (dedupe against what's already imported — `assert`/`require` already present).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./go-framework/hertz/observability/... -run TestNewProvider_With -v`
+Expected: FAIL with `undefined: WithTraceExporter` (compile error) — this is expected since `options.go` doesn't exist yet.
+
+- [ ] **Step 3: Create `go-framework/hertz/observability/options.go`**
+
+```go
+package observability
+
+import (
+	"crypto/tls"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+
+	"go.opentelemetry.io/otel/propagation"
+)
+
+// Option 配置 Provider 的构造行为。
+type Option func(*providerOptions)
+
+// providerOptions 收集 NewProvider 构造期可选配置。
+type providerOptions struct {
+	traceExporter  sdktrace.SpanExporter
+	metricExporter sdkmetric.Exporter
+	sampler        sdktrace.Sampler
+	propagator     propagation.TextMapPropagator
+	tlsConfig      *tls.Config
+}
+
+// WithTraceExporter 注入自定义 trace exporter，跳过内置的 otlptracegrpc 构建。
+// 主要用于单测场景注入内存 exporter（如 tracetest.NewInMemoryExporter()），
+// 避免真实网络连接。
+func WithTraceExporter(exp sdktrace.SpanExporter) Option {
+	return func(o *providerOptions) {
+		if exp != nil {
+			o.traceExporter = exp
+		}
+	}
+}
+
+// WithMetricExporter 注入自定义 metric exporter，跳过内置的 otlpmetricgrpc 构建。
+func WithMetricExporter(exp sdkmetric.Exporter) Option {
+	return func(o *providerOptions) {
+		if exp != nil {
+			o.metricExporter = exp
+		}
+	}
+}
+
+// WithSampler 覆盖默认 sampler（TraceIDRatioBased）。
+func WithSampler(sampler sdktrace.Sampler) Option {
+	return func(o *providerOptions) {
+		if sampler != nil {
+			o.sampler = sampler
+		}
+	}
+}
+
+// WithPropagator 覆盖默认 propagator（b3 + tracecontext + baggage）。
+func WithPropagator(p propagation.TextMapPropagator) Option {
+	return func(o *providerOptions) {
+		if p != nil {
+			o.propagator = p
+		}
+	}
+}
+
+// WithTLSConfig 设置自定义 TLS 配置（自定义 CA、mTLS 证书等）。
+// 优先级高于 cfg.Insecure：一旦提供，exporter 始终使用该 TLS 配置建连。
+// 本函数不解析证书文件路径，证书加载由调用方负责。
+func WithTLSConfig(cfg *tls.Config) Option {
+	return func(o *providerOptions) {
+		if cfg != nil {
+			o.tlsConfig = cfg
+		}
+	}
+}
+
+func newProviderOptions(opts []Option) *providerOptions {
+	o := &providerOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+	return o
+}
+```
+
+- [ ] **Step 4: Modify `go-framework/hertz/observability/provider.go`**
+
+Add imports (`crypto/tls`, `google.golang.org/grpc/credentials`) to the existing import block:
+
+```go
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"time"
+
+	"github.com/cloudwego/hertz/pkg/app"
+	"github.com/cloudwego/hertz/pkg/common/tracer"
+	"github.com/cloudwego/hertz/pkg/common/tracer/stats"
+	runtimemetrics "go.opentelemetry.io/contrib/instrumentation/runtime"
+	"go.opentelemetry.io/contrib/propagators/b3"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/propagation"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.36.0"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc/credentials"
+
+	"github.com/byx-darwin/go-tools/go-framework/config"
+	frameworkerror "github.com/byx-darwin/go-tools/go-framework/error"
+)
+```
+
+Replace the `NewProvider` function body:
+
+```go
+// NewProvider 创建 Hertz OTel Provider（OTLP gRPC 导出）。
+//
+// 同时初始化 Tracing 和 Metrics 双通道：
+//   - Tracing：OTLP gRPC exporter → TracerProvider
+//   - Metrics：OTLP gRPC exporter → MeterProvider + Go runtime metrics
+//
+// 通过 cfg.EnableMetrics 控制是否启用 Metrics（默认 true，当 Enabled=true 时）。
+//
+// exporter 的 TLS 凭据按以下优先级选择：
+//  1. WithTLSConfig 提供的自定义 *tls.Config（自定义 CA / mTLS）
+//  2. cfg.Insecure = true → 明文传输
+//  3. 默认：使用系统根证书池建立 TLS 连接
+//
+// 可通过 WithTraceExporter/WithMetricExporter 注入自定义 exporter（跳过 OTLP gRPC
+// 构建，常用于测试隔离），WithSampler/WithPropagator 覆盖默认 sampler/propagator。
+func NewProvider(ctx context.Context, cfg config.ObservabilityConfig, opts ...Option) (*Provider, error) {
+	p := &Provider{cfg: cfg, shutdown: func(context.Context) error { return nil }}
+	if !cfg.Enabled {
+		return p, nil
+	}
+
+	popts := newProviderOptions(opts)
+
+	res, _ := resource.Merge(resource.Default(),
+		resource.NewWithAttributes(
+			semconv.SchemaURL,
+			semconv.ServiceName(cfg.ServiceName),
+		),
+	)
+
+	// ── Tracing ──
+	var exp sdktrace.SpanExporter
+	if popts.traceExporter != nil {
+		exp = popts.traceExporter
+	} else {
+		traceDialOpts := []otlptracegrpc.Option{otlptracegrpc.WithEndpoint(cfg.Endpoint)}
+		traceDialOpts = append(traceDialOpts, traceTLSOption(cfg, popts))
+
+		var err error
+		exp, err = otlptracegrpc.New(ctx, traceDialOpts...)
+		if err != nil {
+			return nil, frameworkerror.ErrObsTraceExport.Wrap(err)
+		}
+	}
+
+	sampler := sdktrace.TraceIDRatioBased(1.0)
+	if cfg.SampleRate > 0 {
+		sampler = sdktrace.TraceIDRatioBased(cfg.SampleRate)
+	}
+	if popts.sampler != nil {
+		sampler = popts.sampler
+	}
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exp),
+		sdktrace.WithSampler(sampler),
+		sdktrace.WithResource(res),
+	)
+
+	otel.SetTracerProvider(tp)
+
+	propagator := propagation.TextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		b3.New(),
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+	if popts.propagator != nil {
+		propagator = popts.propagator
+	}
+	otel.SetTextMapPropagator(propagator)
+
+	p.tracer = tp.Tracer(cfg.ServiceName)
+	p.shutdown = tp.Shutdown
+
+	// ── Metrics ──
+	if cfg.EnableMetrics {
+		var metricExp sdkmetric.Exporter
+		if popts.metricExporter != nil {
+			metricExp = popts.metricExporter
+		} else {
+			metricDialOpts := []otlpmetricgrpc.Option{otlpmetricgrpc.WithEndpoint(cfg.Endpoint)}
+			metricDialOpts = append(metricDialOpts, metricTLSOption(cfg, popts))
+
+			var err error
+			metricExp, err = otlpmetricgrpc.New(ctx, metricDialOpts...)
+			if err != nil {
+				return nil, frameworkerror.ErrObsMetricExport.Wrap(err)
+			}
+		}
+
+		interval := cfg.MetricsInterval
+		if interval <= 0 {
+			interval = 15 * time.Second
+		}
+
+		reader := sdkmetric.NewPeriodicReader(metricExp, sdkmetric.WithInterval(interval))
+		mp := sdkmetric.NewMeterProvider(
+			sdkmetric.WithReader(reader),
+			sdkmetric.WithResource(res),
+		)
+		otel.SetMeterProvider(mp)
+		p.meterProvider = mp
+
+		// Go runtime metrics（goroutines, GC, memory 等）
+		if err := runtimemetrics.Start(runtimemetrics.WithMeterProvider(mp)); err != nil {
+			return nil, frameworkerror.ErrObsRuntimeMetrics.Wrap(err)
+		}
+
+		// 包装 shutdown 以同时关闭 metrics
+		prevShutdown := p.shutdown
+		p.shutdown = func(ctx context.Context) error {
+			errT := prevShutdown(ctx)
+			errM := mp.Shutdown(ctx)
+			if errT != nil {
+				return errT
+			}
+			return errM
+		}
+	}
+
+	return p, nil
+}
+
+// traceTLSOption 按优先级（WithTLSConfig > cfg.Insecure > 默认 TLS）返回
+// otlptracegrpc 的凭据 Option。
+func traceTLSOption(cfg config.ObservabilityConfig, popts *providerOptions) otlptracegrpc.Option {
+	switch {
+	case popts.tlsConfig != nil:
+		return otlptracegrpc.WithTLSCredentials(credentials.NewTLS(popts.tlsConfig))
+	case cfg.Insecure:
+		return otlptracegrpc.WithInsecure()
+	default:
+		return otlptracegrpc.WithTLSCredentials(credentials.NewTLS(&tls.Config{}))
+	}
+}
+
+// metricTLSOption 按优先级（WithTLSConfig > cfg.Insecure > 默认 TLS）返回
+// otlpmetricgrpc 的凭据 Option。
+func metricTLSOption(cfg config.ObservabilityConfig, popts *providerOptions) otlpmetricgrpc.Option {
+	switch {
+	case popts.tlsConfig != nil:
+		return otlpmetricgrpc.WithTLSCredentials(credentials.NewTLS(popts.tlsConfig))
+	case cfg.Insecure:
+		return otlpmetricgrpc.WithInsecure()
+	default:
+		return otlpmetricgrpc.WithTLSCredentials(credentials.NewTLS(&tls.Config{}))
+	}
+}
+```
+
+Do not change anything else in the file (`ServerMiddleware`, `ServerTracer`, `TracerServerMiddleware`, `Shutdown`, `hertzCarrier` stay as-is).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./go-framework/hertz/observability/... -v`
+Expected: PASS for all tests, including the pre-existing `TestNewProvider_Enabled_InvalidEndpoint` and `TestProvider_Enabled_WithMetrics` (their endpoints are unreachable strings — `otlptracegrpc.New`/`otlpmetricgrpc.New` with gRPC's lazy-connect behavior succeed at construction time regardless of TLS vs plaintext, so these don't need changes)
+
+- [ ] **Step 6: Build check**
+
+Run: `go build ./go-framework/...`
+Expected: success, no compile errors
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add go-framework/hertz/observability/options.go go-framework/hertz/observability/provider.go go-framework/hertz/observability/provider_test.go
+git commit -m "feat(hertz/observability): add Functional Options to NewProvider, default to TLS"
+```
+
+---
+
+### Task 3: Kitex `observability` package — Options + secure-by-default `NewProvider`
+
+**Files:**
+- Create: `go-framework/kitex/observability/options.go`
+- Modify: `go-framework/kitex/observability/provider.go`
+- Test: `go-framework/kitex/observability/provider_test.go`
+
+**Interfaces:**
+- Consumes: `config.ObservabilityConfig.Insecure` (Task 1)
+- Produces: same `Option`/`providerOptions`/`WithTraceExporter`/`WithMetricExporter`/`WithSampler`/`WithPropagator`/`WithTLSConfig` set as Task 2, but scoped to the `kitex/observability` package (separate type, no cross-package sharing — matches design doc's "两个包并行实现" decision). Must NOT collide with the existing `TracerOption`/`tracerConfig` types already defined in `suite.go`.
+- `func NewProvider(ctx context.Context, cfg config.ObservabilityConfig, opts ...Option) (*Provider, error)` (signature change, backward compatible)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `go-framework/kitex/observability/provider_test.go` (rewrite imports to add `"crypto/tls"`, `"testing"` already there, `"github.com/stretchr/testify/require"`, `"go.opentelemetry.io/otel/propagation"`, `sdktrace "go.opentelemetry.io/otel/sdk/trace"`, `"go.opentelemetry.io/otel/sdk/trace/tracetest"`):
+
+```go
+func TestNewProvider_WithTraceExporter_UsesInjectedExporter(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	cfg := config.ObservabilityConfig{
+		Enabled:     true,
+		ServiceName: "test-svc",
+	}
+	p, err := NewProvider(context.Background(), cfg, WithTraceExporter(exp))
+	require.NoError(t, err)
+	require.True(t, p.Enabled())
+
+	_, span := p.tracer.Start(context.Background(), "test-span")
+	span.End()
+	require.NoError(t, p.Shutdown())
+
+	spans := exp.GetSpans()
+	require.Len(t, spans, 1)
+	assert.Equal(t, "test-span", spans[0].Name)
+}
+
+func TestNewProvider_DefaultsToTLS_NotInsecure(t *testing.T) {
+	cfg := config.ObservabilityConfig{
+		Enabled:     true,
+		Endpoint:    "127.0.0.1:1",
+		ServiceName: "test-svc",
+	}
+	p, err := NewProvider(context.Background(), cfg)
+	require.NoError(t, err)
+	require.NoError(t, p.Shutdown())
+}
+
+func TestNewProvider_InsecureTrue_SkipsTLS(t *testing.T) {
+	cfg := config.ObservabilityConfig{
+		Enabled:     true,
+		Endpoint:    "127.0.0.1:1",
+		ServiceName: "test-svc",
+		Insecure:    true,
+	}
+	p, err := NewProvider(context.Background(), cfg)
+	require.NoError(t, err)
+	require.NoError(t, p.Shutdown())
+}
+
+func TestNewProvider_WithTLSConfig_TakesPriorityOverInsecure(t *testing.T) {
+	cfg := config.ObservabilityConfig{
+		Enabled:     true,
+		Endpoint:    "127.0.0.1:1",
+		ServiceName: "test-svc",
+		Insecure:    true,
+	}
+	p, err := NewProvider(context.Background(), cfg, WithTLSConfig(&tls.Config{MinVersion: tls.VersionTLS12}))
+	require.NoError(t, err)
+	require.NoError(t, p.Shutdown())
+}
+
+func TestNewProvider_WithSamplerAndPropagator(t *testing.T) {
+	cfg := config.ObservabilityConfig{
+		Enabled:     true,
+		ServiceName: "test-svc",
+	}
+	p, err := NewProvider(context.Background(), cfg,
+		WithSampler(sdktrace.AlwaysSample()),
+		WithPropagator(propagation.TraceContext{}),
+	)
+	require.NoError(t, err)
+	require.NoError(t, p.Shutdown())
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./go-framework/kitex/observability/... -run TestNewProvider_With -v`
+Expected: FAIL with `undefined: WithTraceExporter` (compile error)
+
+- [ ] **Step 3: Create `go-framework/kitex/observability/options.go`**
+
+```go
+package observability
+
+import (
+	"crypto/tls"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+
+	"go.opentelemetry.io/otel/propagation"
+)
+
+// Option 配置 Provider 的构造行为。
+type Option func(*providerOptions)
+
+// providerOptions 收集 NewProvider 构造期可选配置。
+type providerOptions struct {
+	traceExporter  sdktrace.SpanExporter
+	metricExporter sdkmetric.Exporter
+	sampler        sdktrace.Sampler
+	propagator     propagation.TextMapPropagator
+	tlsConfig      *tls.Config
+}
+
+// WithTraceExporter 注入自定义 trace exporter，跳过内置的 otlptracegrpc 构建。
+// 主要用于单测场景注入内存 exporter（如 tracetest.NewInMemoryExporter()），
+// 避免真实网络连接。
+func WithTraceExporter(exp sdktrace.SpanExporter) Option {
+	return func(o *providerOptions) {
+		if exp != nil {
+			o.traceExporter = exp
+		}
+	}
+}
+
+// WithMetricExporter 注入自定义 metric exporter，跳过内置的 otlpmetricgrpc 构建。
+func WithMetricExporter(exp sdkmetric.Exporter) Option {
+	return func(o *providerOptions) {
+		if exp != nil {
+			o.metricExporter = exp
+		}
+	}
+}
+
+// WithSampler 覆盖默认 sampler（TraceIDRatioBased）。
+func WithSampler(sampler sdktrace.Sampler) Option {
+	return func(o *providerOptions) {
+		if sampler != nil {
+			o.sampler = sampler
+		}
+	}
+}
+
+// WithPropagator 覆盖默认 propagator（b3 + tracecontext + baggage）。
+func WithPropagator(p propagation.TextMapPropagator) Option {
+	return func(o *providerOptions) {
+		if p != nil {
+			o.propagator = p
+		}
+	}
+}
+
+// WithTLSConfig 设置自定义 TLS 配置（自定义 CA、mTLS 证书等）。
+// 优先级高于 cfg.Insecure：一旦提供，exporter 始终使用该 TLS 配置建连。
+// 本函数不解析证书文件路径，证书加载由调用方负责。
+func WithTLSConfig(cfg *tls.Config) Option {
+	return func(o *providerOptions) {
+		if cfg != nil {
+			o.tlsConfig = cfg
+		}
+	}
+}
+
+func newProviderOptions(opts []Option) *providerOptions {
+	o := &providerOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+	return o
+}
+```
+
+- [ ] **Step 4: Modify `go-framework/kitex/observability/provider.go`**
+
+Add imports (`crypto/tls`, `google.golang.org/grpc/credentials`) to the existing import block:
+
+```go
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"time"
+
+	"github.com/byx-darwin/go-tools/go-framework/config"
+	frameworkerror "github.com/byx-darwin/go-tools/go-framework/error"
+	runtimemetrics "go.opentelemetry.io/contrib/instrumentation/runtime"
+	"go.opentelemetry.io/contrib/propagators/b3"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/propagation"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc/credentials"
+)
+```
+
+Replace the `NewProvider` function body (mirrors Task 2's hertz version, same TLS-priority helper functions duplicated in this package):
+
+```go
+// NewProvider 创建 Kitex OTel Provider（OTLP gRPC 导出）。
+//
+// 同时初始化 Tracing 和 Metrics 双通道：
+//   - Tracing：OTLP gRPC exporter → TracerProvider
+//   - Metrics：OTLP gRPC exporter → MeterProvider + Go runtime metrics
+//
+// 通过 cfg.EnableMetrics 控制是否启用 Metrics（默认 true，当 Enabled=true 时）。
+//
+// exporter 的 TLS 凭据按以下优先级选择：
+//  1. WithTLSConfig 提供的自定义 *tls.Config（自定义 CA / mTLS）
+//  2. cfg.Insecure = true → 明文传输
+//  3. 默认：使用系统根证书池建立 TLS 连接
+//
+// 可通过 WithTraceExporter/WithMetricExporter 注入自定义 exporter（跳过 OTLP gRPC
+// 构建，常用于测试隔离），WithSampler/WithPropagator 覆盖默认 sampler/propagator。
+func NewProvider(ctx context.Context, cfg config.ObservabilityConfig, opts ...Option) (*Provider, error) {
+	p := &Provider{cfg: cfg, shutdown: func(context.Context) error { return nil }}
+	if !cfg.Enabled {
+		return p, nil
+	}
+
+	popts := newProviderOptions(opts)
+
+	res, _ := resource.Merge(resource.Default(),
+		resource.NewWithAttributes(
+			semconv.SchemaURL,
+			semconv.ServiceName(cfg.ServiceName),
+		),
+	)
+
+	// ── Tracing ──
+	var exp sdktrace.SpanExporter
+	if popts.traceExporter != nil {
+		exp = popts.traceExporter
+	} else {
+		traceDialOpts := []otlptracegrpc.Option{otlptracegrpc.WithEndpoint(cfg.Endpoint)}
+		traceDialOpts = append(traceDialOpts, traceTLSOption(cfg, popts))
+
+		var err error
+		exp, err = otlptracegrpc.New(ctx, traceDialOpts...)
+		if err != nil {
+			return nil, frameworkerror.ErrObsTraceExport.Wrap(err)
+		}
+	}
+
+	sampler := sdktrace.TraceIDRatioBased(1.0)
+	if cfg.SampleRate > 0 {
+		sampler = sdktrace.TraceIDRatioBased(cfg.SampleRate)
+	}
+	if popts.sampler != nil {
+		sampler = popts.sampler
+	}
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exp),
+		sdktrace.WithSampler(sampler),
+		sdktrace.WithResource(res),
+	)
+
+	otel.SetTracerProvider(tp)
+
+	propagator := propagation.TextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		b3.New(),
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+	if popts.propagator != nil {
+		propagator = popts.propagator
+	}
+	otel.SetTextMapPropagator(propagator)
+
+	p.tracer = tp.Tracer(cfg.ServiceName)
+	p.shutdown = tp.Shutdown
+
+	// ── Metrics ──
+	if cfg.EnableMetrics {
+		var metricExp sdkmetric.Exporter
+		if popts.metricExporter != nil {
+			metricExp = popts.metricExporter
+		} else {
+			metricDialOpts := []otlpmetricgrpc.Option{otlpmetricgrpc.WithEndpoint(cfg.Endpoint)}
+			metricDialOpts = append(metricDialOpts, metricTLSOption(cfg, popts))
+
+			var err error
+			metricExp, err = otlpmetricgrpc.New(ctx, metricDialOpts...)
+			if err != nil {
+				return nil, frameworkerror.ErrObsMetricExport.Wrap(err)
+			}
+		}
+
+		interval := cfg.MetricsInterval
+		if interval <= 0 {
+			interval = 15 * time.Second
+		}
+
+		reader := sdkmetric.NewPeriodicReader(metricExp, sdkmetric.WithInterval(interval))
+		mp := sdkmetric.NewMeterProvider(
+			sdkmetric.WithReader(reader),
+			sdkmetric.WithResource(res),
+		)
+		otel.SetMeterProvider(mp)
+		p.meterProvider = mp
+
+		// Go runtime metrics（goroutines, GC, memory 等）
+		if err := runtimemetrics.Start(runtimemetrics.WithMeterProvider(mp)); err != nil {
+			return nil, frameworkerror.ErrObsRuntimeMetrics.Wrap(err)
+		}
+
+		// 包装 shutdown 以同时关闭 metrics
+		prevShutdown := p.shutdown
+		p.shutdown = func(ctx context.Context) error {
+			errT := prevShutdown(ctx)
+			errM := mp.Shutdown(ctx)
+			if errT != nil {
+				return errT
+			}
+			return errM
+		}
+	}
+
+	return p, nil
+}
+
+// traceTLSOption 按优先级（WithTLSConfig > cfg.Insecure > 默认 TLS）返回
+// otlptracegrpc 的凭据 Option。
+func traceTLSOption(cfg config.ObservabilityConfig, popts *providerOptions) otlptracegrpc.Option {
+	switch {
+	case popts.tlsConfig != nil:
+		return otlptracegrpc.WithTLSCredentials(credentials.NewTLS(popts.tlsConfig))
+	case cfg.Insecure:
+		return otlptracegrpc.WithInsecure()
+	default:
+		return otlptracegrpc.WithTLSCredentials(credentials.NewTLS(&tls.Config{}))
+	}
+}
+
+// metricTLSOption 按优先级（WithTLSConfig > cfg.Insecure > 默认 TLS）返回
+// otlpmetricgrpc 的凭据 Option。
+func metricTLSOption(cfg config.ObservabilityConfig, popts *providerOptions) otlpmetricgrpc.Option {
+	switch {
+	case popts.tlsConfig != nil:
+		return otlpmetricgrpc.WithTLSCredentials(credentials.NewTLS(popts.tlsConfig))
+	case cfg.Insecure:
+		return otlpmetricgrpc.WithInsecure()
+	default:
+		return otlpmetricgrpc.WithTLSCredentials(credentials.NewTLS(&tls.Config{}))
+	}
+}
+```
+
+Do not change anything else in the file (`Enabled`, `MeterProvider`, `Middleware`, `ServerSuite`, `ClientSuite`, `Shutdown` stay as-is).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./go-framework/kitex/observability/... -v`
+Expected: PASS for all tests including pre-existing `TestNewProvider`, `TestProvider_Disabled`, `TestProvider_Shutdown`
+
+- [ ] **Step 6: Build check**
+
+Run: `go build ./go-framework/...`
+Expected: success
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add go-framework/kitex/observability/options.go go-framework/kitex/observability/provider.go go-framework/kitex/observability/provider_test.go
+git commit -m "feat(kitex/observability): add Functional Options to NewProvider, default to TLS"
+```
+
+---
+
+### Task 4: Full validation + migration note
+
+**Files:**
+- Modify: `CLAUDE.md` (or a note under `specs/` — pick `CLAUDE.md`'s existing "Key Decisions" convention: add a one-row entry, no new file)
+
+**Interfaces:**
+- Consumes: nothing new — this task is validation + documentation only.
+
+- [ ] **Step 1: Run full workspace build**
+
+Run: `go build ./go-common/... ./go-auth/... ./go-middleware/... ./go-framework/...`
+Expected: success, no errors
+
+- [ ] **Step 2: Run go vet**
+
+Run: `go vet ./go-common/... ./go-auth/... ./go-middleware/... ./go-framework/...`
+Expected: no issues
+
+- [ ] **Step 3: Run golangci-lint on go-framework**
+
+Run: `golangci-lint run --timeout=5m ./go-framework/...`
+Expected: no issues (check specifically: godoc comments present on all new exported symbols — `Option`, `WithTraceExporter`, `WithMetricExporter`, `WithSampler`, `WithPropagator`, `WithTLSConfig`, `ObservabilityConfig.Insecore` field — and no errcheck violations)
+
+If lint reports issues, fix them in the relevant Task's files and re-run this step (do not proceed until clean).
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `go test ./go-common/... ./go-auth/... ./go-middleware/... ./go-framework/... -count=1`
+Expected: all PASS
+
+- [ ] **Step 5: gofmt check**
+
+Run: `gofmt -l go-framework/config/observability.go go-framework/config/observability_test.go go-framework/hertz/observability/options.go go-framework/hertz/observability/provider.go go-framework/hertz/observability/provider_test.go go-framework/kitex/observability/options.go go-framework/kitex/observability/provider.go go-framework/kitex/observability/provider_test.go`
+Expected: empty output (no files listed)
+
+- [ ] **Step 6: Add migration note to `CLAUDE.md`**
+
+In `CLAUDE.md`, under the `## Key Decisions (Confirmed 2026-06-23)` table, add one row documenting the behavior change (append as a new row, keep table format intact):
+
+```markdown
+| D7 | Observability OTLP TLS default | **Default TLS** (system root cert pool); `ObservabilityConfig.Insecure=true` opts back into plaintext (#96) | ✅ active |
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: record OTLP TLS-by-default migration note (D7, closes #96 groundwork)"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Task 1 covers `Insecure` config field + default-TLS behavior change; Task 2 + Task 3 cover all 5 Options (`WithTraceExporter`, `WithMetricExporter`, `WithSampler`, `WithPropagator`, `WithTLSConfig`) for both hertz and kitex packages per the design's "两个包并行实现" decision; Task 4 covers full validation + migration documentation. Test-isolation via `WithTraceExporter`/`WithMetricExporter` injection is covered in both Task 2 Step 1 and Task 3 Step 1. Out-of-scope items (global singleton refactor, cert file parsing) are explicitly called out in Global Constraints and left untouched.
+- **Type consistency:** `Option`, `providerOptions`, `WithTraceExporter`, `WithMetricExporter`, `WithSampler`, `WithPropagator`, `WithTLSConfig`, `traceTLSOption`, `metricTLSOption` signatures are identical across Task 2 (hertz) and Task 3 (kitex) — verified consistent naming and parameter types throughout.
+- **No placeholders:** all code blocks are complete, runnable Go — no TODO/TBD markers.

--- a/docs/superpowers/specs/2026-09-03-observability-provider-options-design.md
+++ b/docs/superpowers/specs/2026-09-03-observability-provider-options-design.md
@@ -1,0 +1,190 @@
+# Observability Provider Options 设计（Issue #96）
+
+## 背景
+
+`go-framework/hertz/observability/provider.go` 与 `go-framework/kitex/observability/provider.go`
+中的 `NewProvider` 硬编码 OTLP gRPC exporter 为明文传输
+（`otlptracegrpc.WithInsecure()` / `otlpmetricgrpc.WithInsecure()`），且
+sampler（`TraceIDRatioBased`）、propagator（`b3 + tracecontext + baggage`）均写死，
+`NewProvider` 无任何 `...Option` 参数，用户无法替换实现，也无法在测试中注入可控的
+exporter 进行断言。
+
+**安全影响**：遥测数据（可能含请求路径、错误详情等敏感上下文）默认经公网/内网明文传输。
+
+**来源**：多角色框架评审（安全 + 可扩展性视角均独立发现），评估日期 2026-09-02。
+
+## 范围收敛说明
+
+`go-framework/hertz/observability` 与 `go-framework/kitex/observability` 的
+`tracer.go` / `client.go` / `suite.go` / `grpc_metadata.go` 等下游文件广泛依赖
+`otel.GetTracerProvider()` / `otel.GetMeterProvider()` / `otel.GetTextMapPropagator()`
+**全局单例**读取 Provider，而不是从 `Provider` 实例注入。彻底解决"测试中无法隔离"
+需要重构这些下游读取点，改动会扩散到两个包的几乎所有文件，属于比本 Issue 更大范围的
+架构问题。
+
+**本次决策（已与用户确认）**：范围收敛为仅给 `NewProvider` 增加构造期 Options，
+`otel.Set*` 全局设置行为保持不变、下游读取方式不变。全局单例的彻底重构如有需要，
+另开 Issue 跟踪。
+
+"测试隔离"在本次范围内体现为：单测可通过 `WithTraceExporter` / `WithMetricExporter`
+注入内存 exporter，验证 span/metric 内容而不依赖真实网络连接；但多个 `Provider` 实例
+之间仍共享全局 `TracerProvider`（后创建的会覆盖先创建的全局态），这一限制保持现状，
+在 godoc 中注明。
+
+## 设计决策
+
+### 1. TLS 默认行为（行为变更，已与用户确认接受）
+
+- `config.ObservabilityConfig` 新增字段 `Insecure bool`（yaml: `insecure`）
+- **零值 `false` = 默认走 TLS**（系统根证书池），这是一次行为语义变更：
+  升级本库后，未显式配置 `insecure: true` 的用户，exporter 连接方式会从明文变为
+  TLS。若目标 collector 未启用 TLS，连接将失败。
+- **迁移说明**（需在 CHANGELOG / 迁移文档中提示）：
+  > 升级后 OTLP gRPC exporter 默认改为 TLS 连接。如果你的 collector 未启用 TLS
+  > （如本地开发环境的裸 gRPC collector），需要在配置中显式设置 `observability.insecure: true`
+  > 以保留原明文行为。
+
+### 2. TLS 证书配置粒度
+
+- `Insecure bool`（配置项）控制"是否明文"这一开关，与现有 `EnableMetrics` /
+  `EnableGRPCMetadata` 保持同一风格（配置驱动的布尔开关落在 `ObservabilityConfig`
+  struct 上，而非构造期 Option）
+- 新增 `WithTLSConfig(*tls.Config) Option`（构造期 Option，因为 `*tls.Config`
+  不是可 YAML 序列化的值类型）：允许调用方传入自定义 CA / mTLS 证书。
+  **库本身不解析证书文件路径**，加载证书的细节交给调用方。
+
+**exporter TLS 凭据选择优先级**（`NewProvider` 内部）：
+
+```go
+switch {
+case opts.tlsConfig != nil:
+    // 自定义 CA / mTLS，优先级最高
+    dialOpts = append(dialOpts, otlptracegrpc.WithTLSCredentials(credentials.NewTLS(opts.tlsConfig)))
+case cfg.Insecure:
+    // 显式声明明文
+    dialOpts = append(dialOpts, otlptracegrpc.WithInsecure())
+default:
+    // 默认：系统根证书池
+    dialOpts = append(dialOpts, otlptracegrpc.WithTLSCredentials(credentials.NewTLS(&tls.Config{})))
+}
+```
+
+`otlpmetricgrpc` 一侧采用同样的三段式优先级判断。
+
+### 3. Functional Options（遵循 `.claude/rules/options-pattern.md`）
+
+在 `go-framework/hertz/observability/options.go` 与
+`go-framework/kitex/observability/options.go` 中各自新增（两个包并行实现，
+与现有代码重复风格保持一致，不抽公共层，避免跨文件耦合和不必要的重构面）：
+
+```go
+// Option 配置 Provider 构造行为。
+type Option func(*providerOptions)
+
+type providerOptions struct {
+    traceExporter  sdktrace.SpanExporter
+    metricExporter sdkmetric.Exporter
+    sampler        sdktrace.Sampler
+    propagator     propagation.TextMapPropagator
+    tlsConfig      *tls.Config
+}
+
+// WithTraceExporter 注入自定义 trace exporter（跳过 otlptracegrpc 构建）。
+// 主要用于单测注入内存 exporter（如 tracetest.NewInMemoryExporter()）。
+func WithTraceExporter(exp sdktrace.SpanExporter) Option {
+    return func(o *providerOptions) {
+        if exp != nil {
+            o.traceExporter = exp
+        }
+    }
+}
+
+// WithMetricExporter 注入自定义 metric exporter（跳过 otlpmetricgrpc 构建）。
+func WithMetricExporter(exp sdkmetric.Exporter) Option {
+    return func(o *providerOptions) {
+        if exp != nil {
+            o.metricExporter = exp
+        }
+    }
+}
+
+// WithSampler 覆盖默认 sampler（TraceIDRatioBased）。
+func WithSampler(sampler sdktrace.Sampler) Option {
+    return func(o *providerOptions) {
+        if sampler != nil {
+            o.sampler = sampler
+        }
+    }
+}
+
+// WithPropagator 覆盖默认 propagator（b3 + tracecontext + baggage）。
+func WithPropagator(p propagation.TextMapPropagator) Option {
+    return func(o *providerOptions) {
+        if p != nil {
+            o.propagator = p
+        }
+    }
+}
+
+// WithTLSConfig 设置自定义 TLS 配置（自定义 CA / mTLS）。
+// 优先级高于 cfg.Insecure；库不解析证书文件路径，由调用方自行加载证书。
+func WithTLSConfig(cfg *tls.Config) Option {
+    return func(o *providerOptions) {
+        if cfg != nil {
+            o.tlsConfig = cfg
+        }
+    }
+}
+```
+
+`NewProvider` 签名变更为：
+
+```go
+func NewProvider(ctx context.Context, cfg config.ObservabilityConfig, opts ...Option) (*Provider, error)
+```
+
+新增的 `opts ...Option` 是尾部变长参数，**签名向后兼容**，不影响现有调用方
+（`NewProvider(ctx, cfg)` 继续可用）。
+
+若提供了 `WithTraceExporter` / `WithMetricExporter`，则跳过对应的
+`otlptracegrpc.New` / `otlpmetricgrpc.New` 构建，直接使用注入的 exporter；
+`WithSampler` / `WithPropagator` 若提供则直接使用，否则走现有默认逻辑
+（`cfg.SampleRate` → `TraceIDRatioBased`；固定 `b3+tracecontext+baggage`）。
+
+### 4. 错误处理
+
+复用现有 `frameworkerror.ErrObsTraceExport` / `ErrObsMetricExport`
+（20603 / 20604），无需新增错误码。
+
+### 5. Kitex `ServerSuite`/`ClientSuite` 兼容性说明
+
+Kitex 侧 `NewServerSuite(cfg, tracerOpts ...TracerOption)` /
+`NewClientSuite(cfg, tracerOpts ...TracerOption)` 使用的是独立的
+`TracerOption`/`tracerConfig`（控制 `recordSourceOperation` /
+`enableGRPCMetadata`），与本次 `NewProvider` 新增的 `Option`/`providerOptions`
+是两个不同的类型体系，互不冲突，本次不改动 `suite.go`。
+
+## 测试计划
+
+- `go-framework/config/observability_test.go`：补充 `Insecure` 字段默认值
+  （零值 `false`）与显式赋值断言
+- `go-framework/hertz/observability/provider_test.go` / `go-framework/kitex/observability/provider_test.go`：
+  - `WithTraceExporter` 注入 `tracetest.NewInMemoryExporter()` 后，验证
+    Provider 创建成功且不产生真实网络连接
+  - `WithMetricExporter` 同理验证 metrics 侧
+  - `cfg.Insecure = true` 与 `WithTLSConfig` 同时提供时，`WithTLSConfig`
+    优先生效（通过内部可测的分支覆盖，或者以行为不 panic + 无网络报错验证）
+  - 默认（`Insecure` 未设置）路径下 exporter 构建不再显式使用
+    `otlptracegrpc.WithInsecure()`（回归防护，防止行为退化）
+
+## 文档 / 迁移说明
+
+- `CLAUDE.md` 或独立迁移文档记录本次默认行为变更（明文 → 默认 TLS）
+- 两个 `provider.go` 的 godoc 补充新 Option 的用法说明
+
+## 不做的事（Out of Scope）
+
+- 不重构 `otel.GetTracerProvider()` / `GetMeterProvider()` / `GetTextMapPropagator()`
+  全局单例读取点（`tracer.go` / `client.go` / `suite.go` / `grpc_metadata.go`）
+- 不引入证书文件路径解析（PEM 文件加载等），`WithTLSConfig` 只接受已构造好的
+  `*tls.Config`

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -84,6 +84,7 @@ kitex:
 observability:
   enabled: true
   endpoint: "${OTEL_ENDPOINT}"
+  insecure: false  # true 才走明文传输；本地裸 gRPC collector（无 TLS）需要设为 true
   app_key: "${OTEL_APP_KEY}"
   service_name: "go-tools-example"
   sample_rate: 1.0

--- a/go-framework/config/config.go
+++ b/go-framework/config/config.go
@@ -7,6 +7,8 @@ import "time"
 type JaegerOption struct {
 	Enable   bool   `json:"enable" yaml:"enable"`
 	Endpoint string `json:"endpoint"  yaml:"endpoint"`
+	// Insecure 为 true 时使用明文 gRPC 传输（不走 TLS）。默认 false（TLS-by-default）。
+	Insecure bool `json:"insecure" yaml:"insecure"`
 }
 
 // RegistryOption 服务注册中心配置

--- a/go-framework/config/config_test.go
+++ b/go-framework/config/config_test.go
@@ -55,6 +55,12 @@ func TestRegistryOption(t *testing.T) {
 func TestJaegerOption(t *testing.T) {
 	j := JaegerOption{Enable: true, Endpoint: "http://j:14268"}
 	assert.True(t, j.Enable)
+	assert.False(t, j.Insecure)
+}
+
+func TestJaegerOption_Insecure(t *testing.T) {
+	j := JaegerOption{Enable: true, Endpoint: "http://j:14268", Insecure: true}
+	assert.True(t, j.Insecure)
 }
 
 // ── LoadYAML ──

--- a/go-framework/config/observability.go
+++ b/go-framework/config/observability.go
@@ -28,4 +28,10 @@ type ObservabilityConfig struct {
 
 	// EnableGRPCMetadata 启用 gRPC metadata 的 trace context 传播（transport.GRPC 协议时需开启）
 	EnableGRPCMetadata bool `json:"enable_grpc_metadata" yaml:"enable_grpc_metadata"`
+
+	// Insecure 是否允许 OTLP gRPC exporter 使用明文传输（默认 false，即默认走 TLS）。
+	// 零值 false = 默认使用系统根证书池建立 TLS 连接；设为 true 才走明文。
+	// 行为变更提示：升级前版本硬编码明文传输，升级后默认改为 TLS——
+	// 如果你的 collector 未启用 TLS，需要显式设置 insecure: true。
+	Insecure bool `json:"insecure" yaml:"insecure"`
 }

--- a/go-framework/config/observability_test.go
+++ b/go-framework/config/observability_test.go
@@ -44,3 +44,13 @@ func TestObservabilityConfig_MetricsDefaults(t *testing.T) {
 	// MetricsInterval 默认 0，由 Provider 补全为 15s
 	assert.Equal(t, time.Duration(0), c.MetricsInterval)
 }
+
+func TestObservabilityConfig_InsecureDefaultsToFalse(t *testing.T) {
+	c := ObservabilityConfig{}
+	assert.False(t, c.Insecure, "Insecure 零值应为 false（默认走 TLS）")
+}
+
+func TestObservabilityConfig_InsecureExplicitTrue(t *testing.T) {
+	c := ObservabilityConfig{Insecure: true}
+	assert.True(t, c.Insecure)
+}

--- a/go-framework/go.mod
+++ b/go-framework/go.mod
@@ -22,6 +22,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
+	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -90,7 +91,6 @@ require (
 	google.golang.org/genproto v0.0.0-20260622175928-b703f567277d // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260618152121-87f3d3e198d3 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260618152121-87f3d3e198d3 // indirect
-	google.golang.org/grpc v1.82.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go-framework/hertz/observability/options.go
+++ b/go-framework/hertz/observability/options.go
@@ -1,0 +1,79 @@
+package observability
+
+import (
+	"crypto/tls"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+
+	"go.opentelemetry.io/otel/propagation"
+)
+
+// Option 配置 Provider 的构造行为。
+type Option func(*providerOptions)
+
+// providerOptions 收集 NewProvider 构造期可选配置。
+type providerOptions struct {
+	traceExporter  sdktrace.SpanExporter
+	metricExporter sdkmetric.Exporter
+	sampler        sdktrace.Sampler
+	propagator     propagation.TextMapPropagator
+	tlsConfig      *tls.Config
+}
+
+// WithTraceExporter 注入自定义 trace exporter，跳过内置的 otlptracegrpc 构建。
+// 主要用于单测场景注入内存 exporter（如 tracetest.NewInMemoryExporter()），
+// 避免真实网络连接。
+func WithTraceExporter(exp sdktrace.SpanExporter) Option {
+	return func(o *providerOptions) {
+		if exp != nil {
+			o.traceExporter = exp
+		}
+	}
+}
+
+// WithMetricExporter 注入自定义 metric exporter，跳过内置的 otlpmetricgrpc 构建。
+func WithMetricExporter(exp sdkmetric.Exporter) Option {
+	return func(o *providerOptions) {
+		if exp != nil {
+			o.metricExporter = exp
+		}
+	}
+}
+
+// WithSampler 覆盖默认 sampler（TraceIDRatioBased）。
+func WithSampler(sampler sdktrace.Sampler) Option {
+	return func(o *providerOptions) {
+		if sampler != nil {
+			o.sampler = sampler
+		}
+	}
+}
+
+// WithPropagator 覆盖默认 propagator（b3 + tracecontext + baggage）。
+func WithPropagator(p propagation.TextMapPropagator) Option {
+	return func(o *providerOptions) {
+		if p != nil {
+			o.propagator = p
+		}
+	}
+}
+
+// WithTLSConfig 设置自定义 TLS 配置（自定义 CA、mTLS 证书等）。
+// 优先级高于 cfg.Insecure：一旦提供，exporter 始终使用该 TLS 配置建连。
+// 本函数不解析证书文件路径，证书加载由调用方负责。
+func WithTLSConfig(cfg *tls.Config) Option {
+	return func(o *providerOptions) {
+		if cfg != nil {
+			o.tlsConfig = cfg
+		}
+	}
+}
+
+func newProviderOptions(opts []Option) *providerOptions {
+	o := &providerOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+	return o
+}

--- a/go-framework/hertz/observability/provider.go
+++ b/go-framework/hertz/observability/provider.go
@@ -2,6 +2,7 @@ package observability
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"time"
 
@@ -20,6 +21,7 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.36.0"
 	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc/credentials"
 
 	"github.com/byx-darwin/go-tools/go-framework/config"
 	frameworkerror "github.com/byx-darwin/go-tools/go-framework/error"
@@ -40,11 +42,21 @@ type Provider struct {
 //   - Metrics：OTLP gRPC exporter → MeterProvider + Go runtime metrics
 //
 // 通过 cfg.EnableMetrics 控制是否启用 Metrics（默认 true，当 Enabled=true 时）。
-func NewProvider(ctx context.Context, cfg config.ObservabilityConfig) (*Provider, error) {
+//
+// exporter 的 TLS 凭据按以下优先级选择：
+//  1. WithTLSConfig 提供的自定义 *tls.Config（自定义 CA / mTLS）
+//  2. cfg.Insecure = true → 明文传输
+//  3. 默认：使用系统根证书池建立 TLS 连接
+//
+// 可通过 WithTraceExporter/WithMetricExporter 注入自定义 exporter（跳过 OTLP gRPC
+// 构建，常用于测试隔离），WithSampler/WithPropagator 覆盖默认 sampler/propagator。
+func NewProvider(ctx context.Context, cfg config.ObservabilityConfig, opts ...Option) (*Provider, error) {
 	p := &Provider{cfg: cfg, shutdown: func(context.Context) error { return nil }}
 	if !cfg.Enabled {
 		return p, nil
 	}
+
+	popts := newProviderOptions(opts)
 
 	res, _ := resource.Merge(resource.Default(),
 		resource.NewWithAttributes(
@@ -54,17 +66,26 @@ func NewProvider(ctx context.Context, cfg config.ObservabilityConfig) (*Provider
 	)
 
 	// ── Tracing ──
-	exp, err := otlptracegrpc.New(ctx,
-		otlptracegrpc.WithEndpoint(cfg.Endpoint),
-		otlptracegrpc.WithInsecure(),
-	)
-	if err != nil {
-		return nil, frameworkerror.ErrObsTraceExport.Wrap(err)
+	var exp sdktrace.SpanExporter
+	if popts.traceExporter != nil {
+		exp = popts.traceExporter
+	} else {
+		traceDialOpts := []otlptracegrpc.Option{otlptracegrpc.WithEndpoint(cfg.Endpoint)}
+		traceDialOpts = append(traceDialOpts, traceTLSOption(cfg, popts))
+
+		var err error
+		exp, err = otlptracegrpc.New(ctx, traceDialOpts...)
+		if err != nil {
+			return nil, frameworkerror.ErrObsTraceExport.Wrap(err)
+		}
 	}
 
 	sampler := sdktrace.TraceIDRatioBased(1.0)
 	if cfg.SampleRate > 0 {
 		sampler = sdktrace.TraceIDRatioBased(cfg.SampleRate)
+	}
+	if popts.sampler != nil {
+		sampler = popts.sampler
 	}
 
 	tp := sdktrace.NewTracerProvider(
@@ -74,23 +95,34 @@ func NewProvider(ctx context.Context, cfg config.ObservabilityConfig) (*Provider
 	)
 
 	otel.SetTracerProvider(tp)
-	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+
+	propagator := propagation.NewCompositeTextMapPropagator(
 		b3.New(),
 		propagation.TraceContext{},
 		propagation.Baggage{},
-	))
+	)
+	if popts.propagator != nil {
+		propagator = popts.propagator
+	}
+	otel.SetTextMapPropagator(propagator)
 
 	p.tracer = tp.Tracer(cfg.ServiceName)
 	p.shutdown = tp.Shutdown
 
 	// ── Metrics ──
 	if cfg.EnableMetrics {
-		metricExp, err := otlpmetricgrpc.New(ctx,
-			otlpmetricgrpc.WithEndpoint(cfg.Endpoint),
-			otlpmetricgrpc.WithInsecure(),
-		)
-		if err != nil {
-			return nil, frameworkerror.ErrObsMetricExport.Wrap(err)
+		var metricExp sdkmetric.Exporter
+		if popts.metricExporter != nil {
+			metricExp = popts.metricExporter
+		} else {
+			metricDialOpts := []otlpmetricgrpc.Option{otlpmetricgrpc.WithEndpoint(cfg.Endpoint)}
+			metricDialOpts = append(metricDialOpts, metricTLSOption(cfg, popts))
+
+			var err error
+			metricExp, err = otlpmetricgrpc.New(ctx, metricDialOpts...)
+			if err != nil {
+				return nil, frameworkerror.ErrObsMetricExport.Wrap(err)
+			}
 		}
 
 		interval := cfg.MetricsInterval
@@ -124,6 +156,32 @@ func NewProvider(ctx context.Context, cfg config.ObservabilityConfig) (*Provider
 	}
 
 	return p, nil
+}
+
+// traceTLSOption 按优先级（WithTLSConfig > cfg.Insecure > 默认 TLS）返回
+// otlptracegrpc 的凭据 Option。
+func traceTLSOption(cfg config.ObservabilityConfig, popts *providerOptions) otlptracegrpc.Option {
+	switch {
+	case popts.tlsConfig != nil:
+		return otlptracegrpc.WithTLSCredentials(credentials.NewTLS(popts.tlsConfig))
+	case cfg.Insecure:
+		return otlptracegrpc.WithInsecure()
+	default:
+		return otlptracegrpc.WithTLSCredentials(credentials.NewTLS(&tls.Config{}))
+	}
+}
+
+// metricTLSOption 按优先级（WithTLSConfig > cfg.Insecure > 默认 TLS）返回
+// otlpmetricgrpc 的凭据 Option。
+func metricTLSOption(cfg config.ObservabilityConfig, popts *providerOptions) otlpmetricgrpc.Option {
+	switch {
+	case popts.tlsConfig != nil:
+		return otlpmetricgrpc.WithTLSCredentials(credentials.NewTLS(popts.tlsConfig))
+	case cfg.Insecure:
+		return otlpmetricgrpc.WithInsecure()
+	default:
+		return otlpmetricgrpc.WithTLSCredentials(credentials.NewTLS(&tls.Config{}))
+	}
 }
 
 // ServerMiddleware 返回 Hertz 服务端链路追踪中间件（简化版）。

--- a/go-framework/hertz/observability/provider.go
+++ b/go-framework/hertz/observability/provider.go
@@ -158,30 +158,39 @@ func NewProvider(ctx context.Context, cfg config.ObservabilityConfig, opts ...Op
 	return p, nil
 }
 
+// tlsDialCredentials 按优先级（WithTLSConfig > cfg.Insecure > 默认 TLS）返回
+// gRPC 传输凭据。insecure=true 时 creds 为 nil，调用方应使用 exporter 包的
+// WithInsecure()；insecure=false 时 creds 非 nil，调用方应使用
+// WithTLSCredentials(creds)。
+func tlsDialCredentials(cfg config.ObservabilityConfig, popts *providerOptions) (creds credentials.TransportCredentials, insecure bool) {
+	switch {
+	case popts.tlsConfig != nil:
+		return credentials.NewTLS(popts.tlsConfig), false
+	case cfg.Insecure:
+		return nil, true
+	default:
+		return credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12}), false
+	}
+}
+
 // traceTLSOption 按优先级（WithTLSConfig > cfg.Insecure > 默认 TLS）返回
 // otlptracegrpc 的凭据 Option。
 func traceTLSOption(cfg config.ObservabilityConfig, popts *providerOptions) otlptracegrpc.Option {
-	switch {
-	case popts.tlsConfig != nil:
-		return otlptracegrpc.WithTLSCredentials(credentials.NewTLS(popts.tlsConfig))
-	case cfg.Insecure:
+	creds, insecure := tlsDialCredentials(cfg, popts)
+	if insecure {
 		return otlptracegrpc.WithInsecure()
-	default:
-		return otlptracegrpc.WithTLSCredentials(credentials.NewTLS(&tls.Config{}))
 	}
+	return otlptracegrpc.WithTLSCredentials(creds)
 }
 
 // metricTLSOption 按优先级（WithTLSConfig > cfg.Insecure > 默认 TLS）返回
 // otlpmetricgrpc 的凭据 Option。
 func metricTLSOption(cfg config.ObservabilityConfig, popts *providerOptions) otlpmetricgrpc.Option {
-	switch {
-	case popts.tlsConfig != nil:
-		return otlpmetricgrpc.WithTLSCredentials(credentials.NewTLS(popts.tlsConfig))
-	case cfg.Insecure:
+	creds, insecure := tlsDialCredentials(cfg, popts)
+	if insecure {
 		return otlpmetricgrpc.WithInsecure()
-	default:
-		return otlpmetricgrpc.WithTLSCredentials(credentials.NewTLS(&tls.Config{}))
 	}
+	return otlpmetricgrpc.WithTLSCredentials(creds)
 }
 
 // ServerMiddleware 返回 Hertz 服务端链路追踪中间件（简化版）。

--- a/go-framework/hertz/observability/provider_test.go
+++ b/go-framework/hertz/observability/provider_test.go
@@ -3,17 +3,45 @@ package observability
 import (
 	"context"
 	"crypto/tls"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
 	"github.com/byx-darwin/go-tools/go-framework/config"
 )
+
+// fakeMetricExporter 是最小化的 sdkmetric.Exporter 测试替身，用于验证
+// WithMetricExporter 注入的 exporter 确实被使用（而不是内置的 OTLP gRPC
+// exporter）。
+type fakeMetricExporter struct {
+	exportCount int32
+}
+
+func (f *fakeMetricExporter) Temporality(kind sdkmetric.InstrumentKind) metricdata.Temporality {
+	return sdkmetric.DefaultTemporalitySelector(kind)
+}
+
+func (f *fakeMetricExporter) Aggregation(kind sdkmetric.InstrumentKind) sdkmetric.Aggregation {
+	return sdkmetric.DefaultAggregationSelector(kind)
+}
+
+func (f *fakeMetricExporter) Export(_ context.Context, _ *metricdata.ResourceMetrics) error {
+	atomic.AddInt32(&f.exportCount, 1)
+	return nil
+}
+
+func (f *fakeMetricExporter) ForceFlush(_ context.Context) error { return nil }
+
+func (f *fakeMetricExporter) Shutdown(_ context.Context) error { return nil }
 
 func TestNewProvider_Disabled(t *testing.T) {
 	cfg := config.ObservabilityConfig{Enabled: false}
@@ -94,9 +122,9 @@ func TestNewProvider_WithTraceExporter_UsesInjectedExporter(t *testing.T) {
 	// tracetest.InMemoryExporter.Shutdown() 内部会调用 Reset() 清空已存储
 	// 的 span（该 exporter 的已知行为），若在 Shutdown 之后再 GetSpans()
 	// 永远得到空切片，与 NewProvider/Option 实现是否正确无关。
-	if tp, ok := otel.GetTracerProvider().(*sdktrace.TracerProvider); ok {
-		require.NoError(t, tp.ForceFlush(context.Background()))
-	}
+	tp, ok := otel.GetTracerProvider().(*sdktrace.TracerProvider)
+	require.True(t, ok)
+	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exp.GetSpans()
 	require.Len(t, spans, 1)
@@ -159,5 +187,77 @@ func TestNewProvider_WithSamplerAndPropagator(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NotNil(t, p)
+	require.NoError(t, p.Shutdown())
+}
+
+// TestTLSDialCredentials_Priority 是 tlsDialCredentials 的表驱动单测，直接
+// 验证 WithTLSConfig > cfg.Insecure > 默认 TLS 的优先级，不依赖
+// NewProvider 的错误返回值（otlptracegrpc.New 是 lazy-connect，构造期不会
+// 因为凭据错误而报错，因此不能靠 NewProvider 的 err 来做回归保护）。
+func TestTLSDialCredentials_Priority(t *testing.T) {
+	cases := []struct {
+		name         string
+		cfg          config.ObservabilityConfig
+		tlsCfg       *tls.Config
+		wantInsecure bool
+		wantCredsNil bool
+	}{
+		{"default_secure", config.ObservabilityConfig{}, nil, false, false},
+		{"insecure_true", config.ObservabilityConfig{Insecure: true}, nil, true, true},
+		{"tls_config_overrides_insecure", config.ObservabilityConfig{Insecure: true}, &tls.Config{MinVersion: tls.VersionTLS12}, false, false},
+		{"tls_config_alone", config.ObservabilityConfig{}, &tls.Config{MinVersion: tls.VersionTLS12}, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			popts := &providerOptions{}
+			if tc.tlsCfg != nil {
+				WithTLSConfig(tc.tlsCfg)(popts)
+			}
+			creds, insecure := tlsDialCredentials(tc.cfg, popts)
+			assert.Equal(t, tc.wantInsecure, insecure)
+			if tc.wantCredsNil {
+				assert.Nil(t, creds)
+			} else {
+				assert.NotNil(t, creds)
+			}
+		})
+	}
+}
+
+func TestNewProvider_WithMetricExporter_UsesInjectedExporter(t *testing.T) {
+	exp := &fakeMetricExporter{}
+	cfg := config.ObservabilityConfig{
+		Enabled:         true,
+		ServiceName:     "test-svc",
+		EnableMetrics:   true,
+		MetricsInterval: time.Hour, // 避免自动周期性触发，靠 ForceFlush 手动触发
+	}
+	p, err := NewProvider(context.Background(), cfg, WithMetricExporter(exp))
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	require.NotNil(t, p.meterProvider)
+
+	require.NoError(t, p.meterProvider.ForceFlush(context.Background()))
+	assert.GreaterOrEqual(t, atomic.LoadInt32(&exp.exportCount), int32(1))
+
+	require.NoError(t, p.Shutdown())
+}
+
+// TestNewProvider_WithMetricExporter_MetricsDisabled 验证 EnableMetrics=false
+// 时，即便注入了 WithMetricExporter，也不会构建 metrics pipeline
+// （p.meterProvider 保持 nil，注入的 exporter 被静默忽略）。
+func TestNewProvider_WithMetricExporter_MetricsDisabled(t *testing.T) {
+	exp := &fakeMetricExporter{}
+	cfg := config.ObservabilityConfig{
+		Enabled:       true,
+		ServiceName:   "test-svc",
+		EnableMetrics: false,
+	}
+	p, err := NewProvider(context.Background(), cfg, WithMetricExporter(exp))
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	assert.Nil(t, p.meterProvider)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&exp.exportCount))
+
 	require.NoError(t, p.Shutdown())
 }

--- a/go-framework/hertz/observability/provider_test.go
+++ b/go-framework/hertz/observability/provider_test.go
@@ -2,10 +2,15 @@ package observability
 
 import (
 	"context"
+	"crypto/tls"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
 	"github.com/byx-darwin/go-tools/go-framework/config"
 )
@@ -70,4 +75,89 @@ func TestProvider_Enabled_WithMetrics(t *testing.T) {
 	}
 	// We don't assert on the error since gRPC connection may fail in CI.
 	_, _ = NewProvider(context.Background(), cfg)
+}
+
+func TestNewProvider_WithTraceExporter_UsesInjectedExporter(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	cfg := config.ObservabilityConfig{
+		Enabled:     true,
+		ServiceName: "test-svc",
+	}
+	p, err := NewProvider(context.Background(), cfg, WithTraceExporter(exp))
+	require.NoError(t, err)
+	require.NotNil(t, p)
+
+	_, span := p.tracer.Start(context.Background(), "test-span")
+	span.End()
+
+	// ForceFlush（而非直接 Shutdown）以取回已导出的 span：
+	// tracetest.InMemoryExporter.Shutdown() 内部会调用 Reset() 清空已存储
+	// 的 span（该 exporter 的已知行为），若在 Shutdown 之后再 GetSpans()
+	// 永远得到空切片，与 NewProvider/Option 实现是否正确无关。
+	if tp, ok := otel.GetTracerProvider().(*sdktrace.TracerProvider); ok {
+		require.NoError(t, tp.ForceFlush(context.Background()))
+	}
+
+	spans := exp.GetSpans()
+	require.Len(t, spans, 1)
+	assert.Equal(t, "test-span", spans[0].Name)
+
+	require.NoError(t, p.Shutdown())
+}
+
+func TestNewProvider_DefaultsToTLS_NotInsecure(t *testing.T) {
+	// Endpoint 指向不存在的地址；默认走 TLS 时 grpc.NewClient 仍能成功构造
+	// （lazy connect），不应该出现 exporter 构造期错误。这里只验证
+	// NewProvider 在默认（Insecure 未设置）情况下不会因为强制走 TLS 而
+	// 在构造阶段直接报错。
+	cfg := config.ObservabilityConfig{
+		Enabled:     true,
+		Endpoint:    "127.0.0.1:1",
+		ServiceName: "test-svc",
+	}
+	p, err := NewProvider(context.Background(), cfg)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	require.NoError(t, p.Shutdown())
+}
+
+func TestNewProvider_InsecureTrue_SkipsTLS(t *testing.T) {
+	cfg := config.ObservabilityConfig{
+		Enabled:     true,
+		Endpoint:    "127.0.0.1:1",
+		ServiceName: "test-svc",
+		Insecure:    true,
+	}
+	p, err := NewProvider(context.Background(), cfg)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	require.NoError(t, p.Shutdown())
+}
+
+func TestNewProvider_WithTLSConfig_TakesPriorityOverInsecure(t *testing.T) {
+	cfg := config.ObservabilityConfig{
+		Enabled:     true,
+		Endpoint:    "127.0.0.1:1",
+		ServiceName: "test-svc",
+		Insecure:    true, // should be overridden by WithTLSConfig
+	}
+	p, err := NewProvider(context.Background(), cfg, WithTLSConfig(&tls.Config{MinVersion: tls.VersionTLS12}))
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	require.NoError(t, p.Shutdown())
+}
+
+func TestNewProvider_WithSamplerAndPropagator(t *testing.T) {
+	cfg := config.ObservabilityConfig{
+		Enabled:     true,
+		ServiceName: "test-svc",
+	}
+	customPropagator := propagation.TraceContext{}
+	p, err := NewProvider(context.Background(), cfg,
+		WithSampler(sdktrace.AlwaysSample()),
+		WithPropagator(customPropagator),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	require.NoError(t, p.Shutdown())
 }

--- a/go-framework/hertz/server.go
+++ b/go-framework/hertz/server.go
@@ -73,6 +73,7 @@ func NewHTTPServer(ctx context.Context, serverConfig *hertzConfig.ServerConfig) 
 			Enabled:     true,
 			Endpoint:    serverConfig.Jaeger.Endpoint,
 			ServiceName: serverConfig.Registry.Name,
+			Insecure:    serverConfig.Jaeger.Insecure,
 		})
 		if err != nil {
 			return nil, err

--- a/go-framework/kitex/observability/options.go
+++ b/go-framework/kitex/observability/options.go
@@ -1,0 +1,79 @@
+package observability
+
+import (
+	"crypto/tls"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+
+	"go.opentelemetry.io/otel/propagation"
+)
+
+// Option 配置 Provider 的构造行为。
+type Option func(*providerOptions)
+
+// providerOptions 收集 NewProvider 构造期可选配置。
+type providerOptions struct {
+	traceExporter  sdktrace.SpanExporter
+	metricExporter sdkmetric.Exporter
+	sampler        sdktrace.Sampler
+	propagator     propagation.TextMapPropagator
+	tlsConfig      *tls.Config
+}
+
+// WithTraceExporter 注入自定义 trace exporter，跳过内置的 otlptracegrpc 构建。
+// 主要用于单测场景注入内存 exporter（如 tracetest.NewInMemoryExporter()），
+// 避免真实网络连接。
+func WithTraceExporter(exp sdktrace.SpanExporter) Option {
+	return func(o *providerOptions) {
+		if exp != nil {
+			o.traceExporter = exp
+		}
+	}
+}
+
+// WithMetricExporter 注入自定义 metric exporter，跳过内置的 otlpmetricgrpc 构建。
+func WithMetricExporter(exp sdkmetric.Exporter) Option {
+	return func(o *providerOptions) {
+		if exp != nil {
+			o.metricExporter = exp
+		}
+	}
+}
+
+// WithSampler 覆盖默认 sampler（TraceIDRatioBased）。
+func WithSampler(sampler sdktrace.Sampler) Option {
+	return func(o *providerOptions) {
+		if sampler != nil {
+			o.sampler = sampler
+		}
+	}
+}
+
+// WithPropagator 覆盖默认 propagator（b3 + tracecontext + baggage）。
+func WithPropagator(p propagation.TextMapPropagator) Option {
+	return func(o *providerOptions) {
+		if p != nil {
+			o.propagator = p
+		}
+	}
+}
+
+// WithTLSConfig 设置自定义 TLS 配置（自定义 CA、mTLS 证书等）。
+// 优先级高于 cfg.Insecure：一旦提供，exporter 始终使用该 TLS 配置建连。
+// 本函数不解析证书文件路径，证书加载由调用方负责。
+func WithTLSConfig(cfg *tls.Config) Option {
+	return func(o *providerOptions) {
+		if cfg != nil {
+			o.tlsConfig = cfg
+		}
+	}
+}
+
+func newProviderOptions(opts []Option) *providerOptions {
+	o := &providerOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+	return o
+}

--- a/go-framework/kitex/observability/provider.go
+++ b/go-framework/kitex/observability/provider.go
@@ -155,30 +155,39 @@ func NewProvider(ctx context.Context, cfg config.ObservabilityConfig, opts ...Op
 	return p, nil
 }
 
+// tlsDialCredentials 按优先级（WithTLSConfig > cfg.Insecure > 默认 TLS）返回
+// gRPC 传输凭据。insecure=true 时 creds 为 nil，调用方应使用 exporter 包的
+// WithInsecure()；insecure=false 时 creds 非 nil，调用方应使用
+// WithTLSCredentials(creds)。
+func tlsDialCredentials(cfg config.ObservabilityConfig, popts *providerOptions) (creds credentials.TransportCredentials, insecure bool) {
+	switch {
+	case popts.tlsConfig != nil:
+		return credentials.NewTLS(popts.tlsConfig), false
+	case cfg.Insecure:
+		return nil, true
+	default:
+		return credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12}), false
+	}
+}
+
 // traceTLSOption 按优先级（WithTLSConfig > cfg.Insecure > 默认 TLS）返回
 // otlptracegrpc 的凭据 Option。
 func traceTLSOption(cfg config.ObservabilityConfig, popts *providerOptions) otlptracegrpc.Option {
-	switch {
-	case popts.tlsConfig != nil:
-		return otlptracegrpc.WithTLSCredentials(credentials.NewTLS(popts.tlsConfig))
-	case cfg.Insecure:
+	creds, insecure := tlsDialCredentials(cfg, popts)
+	if insecure {
 		return otlptracegrpc.WithInsecure()
-	default:
-		return otlptracegrpc.WithTLSCredentials(credentials.NewTLS(&tls.Config{}))
 	}
+	return otlptracegrpc.WithTLSCredentials(creds)
 }
 
 // metricTLSOption 按优先级（WithTLSConfig > cfg.Insecure > 默认 TLS）返回
 // otlpmetricgrpc 的凭据 Option。
 func metricTLSOption(cfg config.ObservabilityConfig, popts *providerOptions) otlpmetricgrpc.Option {
-	switch {
-	case popts.tlsConfig != nil:
-		return otlpmetricgrpc.WithTLSCredentials(credentials.NewTLS(popts.tlsConfig))
-	case cfg.Insecure:
+	creds, insecure := tlsDialCredentials(cfg, popts)
+	if insecure {
 		return otlpmetricgrpc.WithInsecure()
-	default:
-		return otlpmetricgrpc.WithTLSCredentials(credentials.NewTLS(&tls.Config{}))
 	}
+	return otlpmetricgrpc.WithTLSCredentials(creds)
 }
 
 // Enabled 返回是否启用。

--- a/go-framework/kitex/observability/provider.go
+++ b/go-framework/kitex/observability/provider.go
@@ -3,6 +3,7 @@ package observability
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"time"
 
@@ -20,6 +21,7 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc/credentials"
 )
 
 // Provider Kitex OTel Provider（Tracing + Metrics）。
@@ -37,11 +39,21 @@ type Provider struct {
 //   - Metrics：OTLP gRPC exporter → MeterProvider + Go runtime metrics
 //
 // 通过 cfg.EnableMetrics 控制是否启用 Metrics（默认 true，当 Enabled=true 时）。
-func NewProvider(ctx context.Context, cfg config.ObservabilityConfig) (*Provider, error) {
+//
+// exporter 的 TLS 凭据按以下优先级选择：
+//  1. WithTLSConfig 提供的自定义 *tls.Config（自定义 CA / mTLS）
+//  2. cfg.Insecure = true → 明文传输
+//  3. 默认：使用系统根证书池建立 TLS 连接
+//
+// 可通过 WithTraceExporter/WithMetricExporter 注入自定义 exporter（跳过 OTLP gRPC
+// 构建，常用于测试隔离），WithSampler/WithPropagator 覆盖默认 sampler/propagator。
+func NewProvider(ctx context.Context, cfg config.ObservabilityConfig, opts ...Option) (*Provider, error) {
 	p := &Provider{cfg: cfg, shutdown: func(context.Context) error { return nil }}
 	if !cfg.Enabled {
 		return p, nil
 	}
+
+	popts := newProviderOptions(opts)
 
 	res, _ := resource.Merge(resource.Default(),
 		resource.NewWithAttributes(
@@ -51,17 +63,26 @@ func NewProvider(ctx context.Context, cfg config.ObservabilityConfig) (*Provider
 	)
 
 	// ── Tracing ──
-	exp, err := otlptracegrpc.New(ctx,
-		otlptracegrpc.WithEndpoint(cfg.Endpoint),
-		otlptracegrpc.WithInsecure(),
-	)
-	if err != nil {
-		return nil, frameworkerror.ErrObsTraceExport.Wrap(err)
+	var exp sdktrace.SpanExporter
+	if popts.traceExporter != nil {
+		exp = popts.traceExporter
+	} else {
+		traceDialOpts := []otlptracegrpc.Option{otlptracegrpc.WithEndpoint(cfg.Endpoint)}
+		traceDialOpts = append(traceDialOpts, traceTLSOption(cfg, popts))
+
+		var err error
+		exp, err = otlptracegrpc.New(ctx, traceDialOpts...)
+		if err != nil {
+			return nil, frameworkerror.ErrObsTraceExport.Wrap(err)
+		}
 	}
 
 	sampler := sdktrace.TraceIDRatioBased(1.0)
 	if cfg.SampleRate > 0 {
 		sampler = sdktrace.TraceIDRatioBased(cfg.SampleRate)
+	}
+	if popts.sampler != nil {
+		sampler = popts.sampler
 	}
 
 	tp := sdktrace.NewTracerProvider(
@@ -71,23 +92,34 @@ func NewProvider(ctx context.Context, cfg config.ObservabilityConfig) (*Provider
 	)
 
 	otel.SetTracerProvider(tp)
-	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+
+	propagator := propagation.NewCompositeTextMapPropagator(
 		b3.New(),
 		propagation.TraceContext{},
 		propagation.Baggage{},
-	))
+	)
+	if popts.propagator != nil {
+		propagator = popts.propagator
+	}
+	otel.SetTextMapPropagator(propagator)
 
 	p.tracer = tp.Tracer(cfg.ServiceName)
 	p.shutdown = tp.Shutdown
 
 	// ── Metrics ──
 	if cfg.EnableMetrics {
-		metricExp, err := otlpmetricgrpc.New(ctx,
-			otlpmetricgrpc.WithEndpoint(cfg.Endpoint),
-			otlpmetricgrpc.WithInsecure(),
-		)
-		if err != nil {
-			return nil, frameworkerror.ErrObsMetricExport.Wrap(err)
+		var metricExp sdkmetric.Exporter
+		if popts.metricExporter != nil {
+			metricExp = popts.metricExporter
+		} else {
+			metricDialOpts := []otlpmetricgrpc.Option{otlpmetricgrpc.WithEndpoint(cfg.Endpoint)}
+			metricDialOpts = append(metricDialOpts, metricTLSOption(cfg, popts))
+
+			var err error
+			metricExp, err = otlpmetricgrpc.New(ctx, metricDialOpts...)
+			if err != nil {
+				return nil, frameworkerror.ErrObsMetricExport.Wrap(err)
+			}
 		}
 
 		interval := cfg.MetricsInterval
@@ -121,6 +153,32 @@ func NewProvider(ctx context.Context, cfg config.ObservabilityConfig) (*Provider
 	}
 
 	return p, nil
+}
+
+// traceTLSOption 按优先级（WithTLSConfig > cfg.Insecure > 默认 TLS）返回
+// otlptracegrpc 的凭据 Option。
+func traceTLSOption(cfg config.ObservabilityConfig, popts *providerOptions) otlptracegrpc.Option {
+	switch {
+	case popts.tlsConfig != nil:
+		return otlptracegrpc.WithTLSCredentials(credentials.NewTLS(popts.tlsConfig))
+	case cfg.Insecure:
+		return otlptracegrpc.WithInsecure()
+	default:
+		return otlptracegrpc.WithTLSCredentials(credentials.NewTLS(&tls.Config{}))
+	}
+}
+
+// metricTLSOption 按优先级（WithTLSConfig > cfg.Insecure > 默认 TLS）返回
+// otlpmetricgrpc 的凭据 Option。
+func metricTLSOption(cfg config.ObservabilityConfig, popts *providerOptions) otlpmetricgrpc.Option {
+	switch {
+	case popts.tlsConfig != nil:
+		return otlpmetricgrpc.WithTLSCredentials(credentials.NewTLS(popts.tlsConfig))
+	case cfg.Insecure:
+		return otlpmetricgrpc.WithInsecure()
+	default:
+		return otlpmetricgrpc.WithTLSCredentials(credentials.NewTLS(&tls.Config{}))
+	}
 }
 
 // Enabled 返回是否启用。

--- a/go-framework/kitex/observability/provider_test.go
+++ b/go-framework/kitex/observability/provider_test.go
@@ -3,16 +3,44 @@ package observability
 import (
 	"context"
 	"crypto/tls"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/byx-darwin/go-tools/go-framework/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
+
+// fakeMetricExporter 是最小化的 sdkmetric.Exporter 测试替身，用于验证
+// WithMetricExporter 注入的 exporter 确实被使用（而不是内置的 OTLP gRPC
+// exporter）。
+type fakeMetricExporter struct {
+	exportCount int32
+}
+
+func (f *fakeMetricExporter) Temporality(kind sdkmetric.InstrumentKind) metricdata.Temporality {
+	return sdkmetric.DefaultTemporalitySelector(kind)
+}
+
+func (f *fakeMetricExporter) Aggregation(kind sdkmetric.InstrumentKind) sdkmetric.Aggregation {
+	return sdkmetric.DefaultAggregationSelector(kind)
+}
+
+func (f *fakeMetricExporter) Export(_ context.Context, _ *metricdata.ResourceMetrics) error {
+	atomic.AddInt32(&f.exportCount, 1)
+	return nil
+}
+
+func (f *fakeMetricExporter) ForceFlush(_ context.Context) error { return nil }
+
+func (f *fakeMetricExporter) Shutdown(_ context.Context) error { return nil }
 
 func TestNewProvider(t *testing.T) {
 	ctx := context.Background()
@@ -66,9 +94,9 @@ func TestNewProvider_WithTraceExporter_UsesInjectedExporter(t *testing.T) {
 	// tracetest.InMemoryExporter.Shutdown() 内部会调用 Reset() 清空已存储
 	// 的 span（该 exporter 的已知行为），若在 Shutdown 之后再 GetSpans()
 	// 永远得到空切片，与 NewProvider/Option 实现是否正确无关。
-	if tp, ok := otel.GetTracerProvider().(*sdktrace.TracerProvider); ok {
-		require.NoError(t, tp.ForceFlush(context.Background()))
-	}
+	tp, ok := otel.GetTracerProvider().(*sdktrace.TracerProvider)
+	require.True(t, ok)
+	require.NoError(t, tp.ForceFlush(context.Background()))
 
 	spans := exp.GetSpans()
 	require.Len(t, spans, 1)
@@ -78,6 +106,10 @@ func TestNewProvider_WithTraceExporter_UsesInjectedExporter(t *testing.T) {
 }
 
 func TestNewProvider_DefaultsToTLS_NotInsecure(t *testing.T) {
+	// Endpoint 指向不存在的地址；默认走 TLS 时 grpc.NewClient 仍能成功构造
+	// （lazy connect），不应该出现 exporter 构造期错误。这里只验证
+	// NewProvider 在默认（Insecure 未设置）情况下不会因为强制走 TLS 而
+	// 在构造阶段直接报错。
 	cfg := config.ObservabilityConfig{
 		Enabled:     true,
 		Endpoint:    "127.0.0.1:1",
@@ -122,5 +154,77 @@ func TestNewProvider_WithSamplerAndPropagator(t *testing.T) {
 		WithPropagator(propagation.TraceContext{}),
 	)
 	require.NoError(t, err)
+	require.NoError(t, p.Shutdown())
+}
+
+// TestTLSDialCredentials_Priority 是 tlsDialCredentials 的表驱动单测，直接
+// 验证 WithTLSConfig > cfg.Insecure > 默认 TLS 的优先级，不依赖
+// NewProvider 的错误返回值（otlptracegrpc.New 是 lazy-connect，构造期不会
+// 因为凭据错误而报错，因此不能靠 NewProvider 的 err 来做回归保护）。
+func TestTLSDialCredentials_Priority(t *testing.T) {
+	cases := []struct {
+		name         string
+		cfg          config.ObservabilityConfig
+		tlsCfg       *tls.Config
+		wantInsecure bool
+		wantCredsNil bool
+	}{
+		{"default_secure", config.ObservabilityConfig{}, nil, false, false},
+		{"insecure_true", config.ObservabilityConfig{Insecure: true}, nil, true, true},
+		{"tls_config_overrides_insecure", config.ObservabilityConfig{Insecure: true}, &tls.Config{MinVersion: tls.VersionTLS12}, false, false},
+		{"tls_config_alone", config.ObservabilityConfig{}, &tls.Config{MinVersion: tls.VersionTLS12}, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			popts := &providerOptions{}
+			if tc.tlsCfg != nil {
+				WithTLSConfig(tc.tlsCfg)(popts)
+			}
+			creds, insecure := tlsDialCredentials(tc.cfg, popts)
+			assert.Equal(t, tc.wantInsecure, insecure)
+			if tc.wantCredsNil {
+				assert.Nil(t, creds)
+			} else {
+				assert.NotNil(t, creds)
+			}
+		})
+	}
+}
+
+func TestNewProvider_WithMetricExporter_UsesInjectedExporter(t *testing.T) {
+	exp := &fakeMetricExporter{}
+	cfg := config.ObservabilityConfig{
+		Enabled:         true,
+		ServiceName:     "test-svc",
+		EnableMetrics:   true,
+		MetricsInterval: time.Hour, // 避免自动周期性触发，靠 ForceFlush 手动触发
+	}
+	p, err := NewProvider(context.Background(), cfg, WithMetricExporter(exp))
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	require.NotNil(t, p.meterProvider)
+
+	require.NoError(t, p.meterProvider.ForceFlush(context.Background()))
+	assert.GreaterOrEqual(t, atomic.LoadInt32(&exp.exportCount), int32(1))
+
+	require.NoError(t, p.Shutdown())
+}
+
+// TestNewProvider_WithMetricExporter_MetricsDisabled 验证 EnableMetrics=false
+// 时，即便注入了 WithMetricExporter，也不会构建 metrics pipeline
+// （p.meterProvider 保持 nil，注入的 exporter 被静默忽略）。
+func TestNewProvider_WithMetricExporter_MetricsDisabled(t *testing.T) {
+	exp := &fakeMetricExporter{}
+	cfg := config.ObservabilityConfig{
+		Enabled:       true,
+		ServiceName:   "test-svc",
+		EnableMetrics: false,
+	}
+	p, err := NewProvider(context.Background(), cfg, WithMetricExporter(exp))
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	assert.Nil(t, p.meterProvider)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&exp.exportCount))
+
 	require.NoError(t, p.Shutdown())
 }

--- a/go-framework/kitex/observability/provider_test.go
+++ b/go-framework/kitex/observability/provider_test.go
@@ -2,10 +2,16 @@ package observability
 
 import (
 	"context"
+	"crypto/tls"
 	"testing"
 
 	"github.com/byx-darwin/go-tools/go-framework/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 func TestNewProvider(t *testing.T) {
@@ -41,4 +47,80 @@ func TestProvider_Disabled(t *testing.T) {
 func TestProvider_Shutdown(t *testing.T) {
 	p, _ := NewProvider(context.Background(), config.ObservabilityConfig{})
 	assert.NoError(t, p.Shutdown())
+}
+
+func TestNewProvider_WithTraceExporter_UsesInjectedExporter(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	cfg := config.ObservabilityConfig{
+		Enabled:     true,
+		ServiceName: "test-svc",
+	}
+	p, err := NewProvider(context.Background(), cfg, WithTraceExporter(exp))
+	require.NoError(t, err)
+	require.True(t, p.Enabled())
+
+	_, span := p.tracer.Start(context.Background(), "test-span")
+	span.End()
+
+	// ForceFlush（而非直接 Shutdown）以取回已导出的 span：
+	// tracetest.InMemoryExporter.Shutdown() 内部会调用 Reset() 清空已存储
+	// 的 span（该 exporter 的已知行为），若在 Shutdown 之后再 GetSpans()
+	// 永远得到空切片，与 NewProvider/Option 实现是否正确无关。
+	if tp, ok := otel.GetTracerProvider().(*sdktrace.TracerProvider); ok {
+		require.NoError(t, tp.ForceFlush(context.Background()))
+	}
+
+	spans := exp.GetSpans()
+	require.Len(t, spans, 1)
+	assert.Equal(t, "test-span", spans[0].Name)
+
+	require.NoError(t, p.Shutdown())
+}
+
+func TestNewProvider_DefaultsToTLS_NotInsecure(t *testing.T) {
+	cfg := config.ObservabilityConfig{
+		Enabled:     true,
+		Endpoint:    "127.0.0.1:1",
+		ServiceName: "test-svc",
+	}
+	p, err := NewProvider(context.Background(), cfg)
+	require.NoError(t, err)
+	require.NoError(t, p.Shutdown())
+}
+
+func TestNewProvider_InsecureTrue_SkipsTLS(t *testing.T) {
+	cfg := config.ObservabilityConfig{
+		Enabled:     true,
+		Endpoint:    "127.0.0.1:1",
+		ServiceName: "test-svc",
+		Insecure:    true,
+	}
+	p, err := NewProvider(context.Background(), cfg)
+	require.NoError(t, err)
+	require.NoError(t, p.Shutdown())
+}
+
+func TestNewProvider_WithTLSConfig_TakesPriorityOverInsecure(t *testing.T) {
+	cfg := config.ObservabilityConfig{
+		Enabled:     true,
+		Endpoint:    "127.0.0.1:1",
+		ServiceName: "test-svc",
+		Insecure:    true,
+	}
+	p, err := NewProvider(context.Background(), cfg, WithTLSConfig(&tls.Config{MinVersion: tls.VersionTLS12}))
+	require.NoError(t, err)
+	require.NoError(t, p.Shutdown())
+}
+
+func TestNewProvider_WithSamplerAndPropagator(t *testing.T) {
+	cfg := config.ObservabilityConfig{
+		Enabled:     true,
+		ServiceName: "test-svc",
+	}
+	p, err := NewProvider(context.Background(), cfg,
+		WithSampler(sdktrace.AlwaysSample()),
+		WithPropagator(propagation.TraceContext{}),
+	)
+	require.NoError(t, err)
+	require.NoError(t, p.Shutdown())
 }


### PR DESCRIPTION
## Summary

- `go-framework/config/observability.go`: add `Insecure bool` to `ObservabilityConfig` (default `false` → OTLP gRPC exporter now defaults to TLS, was hardcoded plaintext)
- `go-framework/hertz/observability` and `go-framework/kitex/observability`: add Functional Options to `NewProvider` — `WithTraceExporter`, `WithMetricExporter`, `WithSampler`, `WithPropagator`, `WithTLSConfig` (priority: `WithTLSConfig` > `cfg.Insecure` > default TLS with system root cert pool)
- `go-framework/config/config.go` + `go-framework/hertz/server.go`: add `Insecure` escape hatch to `JaegerOption` so `hertz.NewHTTPServer`'s internal Jaeger wiring isn't forced onto TLS with no config path
- `tlsDialCredentials` helper (both packages) with real table-driven regression tests for the TLS priority logic — not just "NewProvider doesn't error"
- `WithMetricExporter` test coverage via an in-memory test double (previously untested)
- `CLAUDE.md` D7 row + `example/config.yaml` documenting the new `insecure` key

**Breaking behavior change (intentional, documented):** OTLP gRPC exporters now default to TLS instead of plaintext. Deployments pointing at a plaintext collector need to set `observability.insecure: true` (or `jaeger.insecure: true` for the legacy Hertz Jaeger path) to keep the old behavior.

Design doc: `docs/superpowers/specs/2026-09-03-observability-provider-options-design.md`
Implementation plan: `docs/superpowers/plans/2026-09-03-observability-provider-options.md`

Closes #96

## Test plan

- [x] `go build ./go-common/... ./go-auth/... ./go-middleware/... ./go-framework/...`
- [x] `go vet` clean
- [x] `golangci-lint run` clean across all 4 modules (0 issues)
- [x] `go test ./go-common/... ./go-auth/... ./go-middleware/... ./go-framework/... -count=1` — all green
- [x] `gofmt -l` clean on all touched files
- [x] New regression tests: `TestTLSDialCredentials_Priority` (hertz + kitex), `WithMetricExporter` injection tests (hertz + kitex), `JaegerOption` Insecure field test
- [x] Backward compatibility verified: all existing `NewProvider(ctx, cfg)` 2-arg call sites in the repo (`example/main.go`, `go-framework/hertz/server.go`) still compile unchanged